### PR TITLE
less: prevent source in <pre> from wrapping

### DIFF
--- a/cmd/gddo-server/less/local.less
+++ b/cmd/gddo-server/less/local.less
@@ -12,6 +12,13 @@ code {
   padding: 0;
 }
 
+pre {
+  overflow-x: auto;
+  word-wrap: normal;
+  word-break: normal;
+  white-space: pre;
+}
+
 .import {
   padding: 0;
   border: 0 none black;


### PR DESCRIPTION
bootstrap wraps the text in `<pre>`s by default, this makes reading
source code harder since you can confuse the wrapped line as a new one.

To be honest, I have never used less and I don't know if this is even right, please drop me a line if it is not :)
