### PR TITLE
Fixes unnecessary space between date and period in html template.

### DIFF
--- a/gddo-server/assets/templates/common.html
+++ b/gddo-server/assets/templates/common.html
@@ -25,7 +25,7 @@
   {{.pdoc.Breadcrumbs templateName}}
   {{if and .pdoc.Name (equal templateName "pkg.html")}}
   <span class="pull-right">
-    <a href="#pkg-index">Index</a> 
+    <a href="#pkg-index">Index</a>
     {{if .pdoc.AllExamples}}<span class="text-muted">|</span> <a href="#pkg-examples">Examples</a>{{end}}
     <span class="text-muted">|</span> <a href="#pkg-files">Files</a>
     {{if .pkgs}}<span class="text-muted">|</span> <a href="#pkg-subdirectories">Directories</a>{{end}}
@@ -73,8 +73,7 @@
 {{with $.pdoc}}
   <form name="x-refresh" method="POST" action="/-/refresh"><input type="hidden" name="path" value="{{.ImportPath}}"></form>
   <p>{{if or .Imports $.importerCount}}Package {{.Name}} {{if .Imports}}imports <a href="?imports">{{.Imports|len}} packages</a> (<a href="?import-graph">graph</a>){{end}}{{if and .Imports $.importerCount}} and {{end}}{{if $.importerCount}}is imported by <a href="?importers">{{$.importerCount}} packages</a>{{end}}.{{end}}
-  {{if not .Updated.IsZero}}Updated <span class="timeago" title="{{.Updated.Format "2006-01-02T15:04:05Z"}}">{{.Updated.Format "2006-01-02"}}</span>
-    {{if or (equal .GOOS "windows") (equal .GOOS "darwin")}} with GOOS={{.GOOS}}{{end}}.{{end}}
+  {{if not .Updated.IsZero}}Updated <span class="timeago" title="{{.Updated.Format "2006-01-02T15:04:05Z"}}">{{.Updated.Format "2006-01-02"}}</span>{{if or (equal .GOOS "windows") (equal .GOOS "darwin")}} with GOOS={{.GOOS}}{{end}}.{{end}}
   <a href="javascript:document.getElementsByName('x-refresh')[0].submit();" title="Refresh this page from the source.">Refresh</a>.
 {{end}}{{end}}
 


### PR DESCRIPTION
Before this patch:

![image](https://f.cloud.github.com/assets/1924134/944643/a39ed222-02c8-11e3-8b94-a1f5b39d9c6b.png)

After:

![image](https://f.cloud.github.com/assets/1924134/944644/bc7406d2-02c8-11e3-9483-b3e7599b2d17.png)

Also trims unnecessary trailing space on line 28.
