### PR TITLE
Corrected README with the correct filename mention.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -36,7 +36,7 @@ Development Environment Setup
 
 Optional:
 
-- Create the file gddo-server/config.go using the template in gddo-server/config.go.example.
+- Create the file gddo-server/config.go using the template in [gddo-server/config.go.template](gddo-server/config.go.template).
 
 License
 -------


### PR DESCRIPTION
The correct filename is `gddo-server/config.go.template`, not `gddo-server/config.go.example`.

Also turned it a link (optional change).
