### PR TITLE
disable https for badge

### DIFF
--- a/gddo-server/main.go
+++ b/gddo-server/main.go
@@ -295,9 +295,9 @@ func servePackage(resp http.ResponseWriter, req *http.Request) error {
 		})
 	case isView(req, "tools"):
 		proto := "http"
-		if req.Host == "godoc.org" {
-			proto = "https"
-		}
+		// if req.Host == "godoc.org" {
+		// 	proto = "https"
+		// }
 		return executeTemplate(resp, "tools.html", http.StatusOK, nil, map[string]interface{}{
 			"uri":  fmt.Sprintf("%s://%s/%s", proto, req.Host, importPath),
 			"pdoc": newTDoc(pdoc),


### PR DESCRIPTION
since certificate chain isn't working in Firefox https://github.com/garyburd/gddo/issues/134#issuecomment-31569614

@garyburd Perhaps it's better to not have HTTPS than to have it not working, especially since it's not absolutely required right now.
