### PR TITLE
Accept non source urls for github

### DIFF
--- a/gddo-server/browse.go
+++ b/gddo-server/browse.go
@@ -60,6 +60,11 @@ var browsePatterns = []struct {
 		},
 	},
 	{
+		// GitHub issues, pulls, etc.
+		regexp.MustCompile(`^https?://(github\.com/[^/]+/[^/]+)(.*)$`),
+		func(m []string) string { return m[1] },
+	},
+	{
 		// Bitbucket source borwser.
 		regexp.MustCompile(`^https?://(bitbucket\.org/[^/]+/[^/]+)(?:/src/[^/]+(/[^?]+)?)?`),
 		func(m []string) string { return m[1] + m[2] },

--- a/gddo-server/browse_test.go
+++ b/gddo-server/browse_test.go
@@ -17,6 +17,7 @@ var isBrowseURLTests = []struct {
 }{
 	{"https://github.com/garyburd/gddo/blob/master/doc/code.go", "github.com/garyburd/gddo/doc", true},
 	{"https://github.com/garyburd/go-oauth/blob/master/.gitignore", "github.com/garyburd/go-oauth", true},
+	{"https://github.com/garyburd/gddo/issues/154", "github.com/garyburd/gddo", true},
 	{"https://bitbucket.org/user/repo/src/bd0b661a263e/p1/p2?at=default", "bitbucket.org/user/repo/p1/p2", true},
 	{"https://bitbucket.org/user/repo/src", "bitbucket.org/user/repo", true},
 	{"https://bitbucket.org/user/repo", "bitbucket.org/user/repo", true},


### PR DESCRIPTION
If the url for a github repository is pointing to something other than source code (i.e. tree or blob) redirect to the project root.
