### PR TITLE
Remove redundant .close() call

### DIFF
--- a/gosrc/client.go
+++ b/gosrc/client.go
@@ -55,7 +55,6 @@ func (c *httpClient) getBytes(url string) ([]byte, error) {
 		return nil, c.err(resp)
 	}
 	p, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
 	return p, err
 }
 


### PR DESCRIPTION
`defer resp.Body.Close()` above should suffice to close the stream.
