### PR TITLE
Mention correct Go version in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -23,7 +23,7 @@ Development Environment Setup
 -----------------------------
 
 - Install and run [Redis 2.8.x](http://redis.io/download). The redis.conf file included in the Redis distribution is suitable for development.
-- Install Go 1.2.
+- Install Go 1.4.
 - Install and run the server:
 
         $ go get github.com/golang/gddo/gddo-server


### PR DESCRIPTION
The new `for-range` syntax [used here](https://github.com/golang/gddo/blob/ff26967b097e6981d2fb66bba2e834e6c4794d92/gosrc/client.go#L118) requires Go 1.4, as mentioned in the [beta release notes](http://tip.golang.org/doc/go1.4#forrange)
