### PR TITLE
Enable package import comment redirect.

### DIFF
--- a/doc/builder.go
+++ b/doc/builder.go
@@ -509,9 +509,7 @@ func newPackage(dir *gosrc.Directory) (*Package, error) {
 	for _, env := range goEnvs {
 		ctxt.GOOS = env.GOOS
 		ctxt.GOARCH = env.GOARCH
-		// TODO(garyburd): Change second argument to build.ImportComment when
-		// gddo is upgraded to Go 1.4.
-		bpkg, err = dir.Import(&ctxt, 0 /* build.ImportComment */)
+		bpkg, err = dir.Import(&ctxt, build.ImportComment)
 		if _, ok := err.(*build.NoGoError); !ok {
 			break
 		}
@@ -523,19 +521,12 @@ func newPackage(dir *gosrc.Directory) (*Package, error) {
 		return pkg, nil
 	}
 
-	/*
-	        TODO(garyburd): This block of code uses the import comment feature
-	        added in Go 1.4. Uncomment this block when gddo upgraded to Go 1.4.
-	        Also, change the second argument to dir.Import above from 0 to
-	        build.ImportComment.
-
-			if bpkg.ImportComment != "" && bpkg.ImportComment != dir.ImportPath {
-				return nil, gosrc.NotFoundError{
-					Message:  "not at canonical import path",
-					Redirect: bpkg.ImportComment,
-				}
-			}
-	*/
+	if bpkg.ImportComment != "" && bpkg.ImportComment != dir.ImportPath {
+		return nil, gosrc.NotFoundError{
+			Message:  "not at canonical import path",
+			Redirect: bpkg.ImportComment,
+		}
+	}
 
 	// Parse the Go files
 

--- a/gddo-server/assets/templates/common.html
+++ b/gddo-server/assets/templates/common.html
@@ -20,7 +20,7 @@
   </form>
 {{end}}
 
-{{define "ProjectNav"}}<div class="clearfix" id="x-projnav">
+{{define "ProjectNav"}}{{template "FlashMessages" .flashMessages}}<div class="clearfix" id="x-projnav">
   {{if .pdoc.ProjectRoot}}{{if .pdoc.ProjectURL}}<a href="{{.pdoc.ProjectURL}}"><strong>{{.pdoc.ProjectName}}:</strong></a>{{else}}<strong>{{.pdoc.ProjectName}}:</strong>{{end}}{{else}}<a href="/-/go">Go:</a>{{end}}
   {{.pdoc.Breadcrumbs templateName}}
   {{if and .pdoc.Name (equal templateName "pkg.html")}}
@@ -84,3 +84,10 @@
 {{define "Bootstrap.css"}}<link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css" rel="stylesheet">{{end}}
 {{define "Bootstrap.js"}}<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>{{end}}
 {{define "jQuery"}}<script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>{{end}}
+
+{{define "FlashMessages"}}{{range .}}
+  {{if eq .ID "redir"}}{{if eq (len .Args) 1}}<div class="alert alert-warning">Redirected from {{index .Args 0}}.</div>{{end}}
+  {{else if eq .ID "refresh"}}{{if eq (len .Args) 1}}<div class="alert alert-danger">Error refreshing package: {{index .Args 0}}</div>{{end}}
+  {{end}}
+{{end}}{{end}}
+

--- a/gddo-server/assets/templates/file.html
+++ b/gddo-server/assets/templates/file.html
@@ -1,8 +1,0 @@
-{{define "Head"}}<title>{{.pdoc.PageName}} - GoDoc</title><meta name="robots" content="NOINDEX, NOFOLLOW">{{end}}
-
-{{define "Body"}}
-  {{template "ProjectNav" $}}
-  <h3>{{.fname}}</h3>
-  <pre id="x-file">{{.src}}</pre>
-  {{with host .url}}<p>View the file on <a href="{{$.url}}">{{.}}</a>.{{end}}
-{{end}}

--- a/gddo-server/main.go
+++ b/gddo-server/main.go
@@ -172,7 +172,7 @@ func isView(req *http.Request, key string) bool {
 }
 
 // httpEtag returns the package entity tag used in HTTP transactions.
-func httpEtag(pdoc *doc.Package, pkgs []database.Package, importerCount int) string {
+func httpEtag(pdoc *doc.Package, pkgs []database.Package, importerCount int, flashMessages []flashMessage) string {
 	b := make([]byte, 0, 128)
 	b = strconv.AppendInt(b, pdoc.Updated.Unix(), 16)
 	b = append(b, 0)
@@ -190,6 +190,14 @@ func httpEtag(pdoc *doc.Package, pkgs []database.Package, importerCount int) str
 	}
 	if *sidebarEnabled {
 		b = append(b, "\000xsb"...)
+	}
+	for _, m := range flashMessages {
+		b = append(b, 0)
+		b = append(b, m.ID...)
+		for _, a := range m.Args {
+			b = append(b, 1)
+			b = append(b, a...)
+		}
 	}
 	h := md5.New()
 	h.Write(b)
@@ -235,12 +243,15 @@ func servePackage(resp http.ResponseWriter, req *http.Request) error {
 		if req.URL.RawQuery != "" {
 			u += "?" + req.URL.RawQuery
 		}
-		http.Redirect(resp, req, u, http.StatusMovedPermanently)
+		setFlashMessages(resp, []flashMessage{{ID: "redir", Args: []string{importPath}}})
+		http.Redirect(resp, req, u, http.StatusFound)
 		return nil
 	}
 	if err != nil {
 		return err
 	}
+
+	flashMessages := getFlashMessages(resp, req)
 
 	if pdoc == nil {
 		if len(pkgs) == 0 {
@@ -268,7 +279,7 @@ func servePackage(resp http.ResponseWriter, req *http.Request) error {
 			}
 		}
 
-		etag := httpEtag(pdoc, pkgs, importerCount)
+		etag := httpEtag(pdoc, pkgs, importerCount, flashMessages)
 		status := http.StatusOK
 		if req.Header.Get("If-None-Match") == etag {
 			status = http.StatusNotModified
@@ -295,6 +306,7 @@ func servePackage(resp http.ResponseWriter, req *http.Request) error {
 		template += templateExt(req)
 
 		return executeTemplate(resp, template, status, http.Header{"Etag": {etag}}, map[string]interface{}{
+			"flashMessages": flashMessages,
 			"pkgs":          pkgs,
 			"pdoc":          newTDoc(pdoc),
 			"importerCount": importerCount,
@@ -308,8 +320,9 @@ func servePackage(resp http.ResponseWriter, req *http.Request) error {
 			return err
 		}
 		return executeTemplate(resp, "imports.html", http.StatusOK, nil, map[string]interface{}{
-			"pkgs": pkgs,
-			"pdoc": newTDoc(pdoc),
+			"flashMessages": flashMessages,
+			"pkgs":          pkgs,
+			"pdoc":          newTDoc(pdoc),
 		})
 	case isView(req, "tools"):
 		proto := "http"
@@ -317,8 +330,9 @@ func servePackage(resp http.ResponseWriter, req *http.Request) error {
 			proto = "https"
 		}
 		return executeTemplate(resp, "tools.html", http.StatusOK, nil, map[string]interface{}{
-			"uri":  fmt.Sprintf("%s://%s/%s", proto, req.Host, importPath),
-			"pdoc": newTDoc(pdoc),
+			"flashMessages": flashMessages,
+			"uri":           fmt.Sprintf("%s://%s/%s", proto, req.Host, importPath),
+			"pdoc":          newTDoc(pdoc),
 		})
 	case isView(req, "importers"):
 		if pdoc.Name == "" {
@@ -334,8 +348,9 @@ func servePackage(resp http.ResponseWriter, req *http.Request) error {
 			template = "importers_robot.html"
 		}
 		return executeTemplate(resp, template, http.StatusOK, nil, map[string]interface{}{
-			"pkgs": pkgs,
-			"pdoc": newTDoc(pdoc),
+			"flashMessages": flashMessages,
+			"pkgs":          pkgs,
+			"pdoc":          newTDoc(pdoc),
 		})
 	case isView(req, "import-graph"):
 		if pdoc.Name == "" {
@@ -357,9 +372,10 @@ func servePackage(resp http.ResponseWriter, req *http.Request) error {
 			return err
 		}
 		return executeTemplate(resp, "graph.html", http.StatusOK, nil, map[string]interface{}{
-			"svg":  template.HTML(b),
-			"pdoc": newTDoc(pdoc),
-			"hide": hide,
+			"flashMessages": flashMessages,
+			"svg":           template.HTML(b),
+			"pdoc":          newTDoc(pdoc),
+			"hide":          hide,
 		})
 	case isView(req, "play"):
 		u, err := playURL(pdoc, req.Form.Get("play"))
@@ -392,14 +408,14 @@ func servePackage(resp http.ResponseWriter, req *http.Request) error {
 }
 
 func serveRefresh(resp http.ResponseWriter, req *http.Request) error {
-	path := req.Form.Get("path")
-	_, pkgs, _, err := db.Get(path)
+	importPath := req.Form.Get("path")
+	_, pkgs, _, err := db.Get(importPath)
 	if err != nil {
 		return err
 	}
 	c := make(chan error, 1)
 	go func() {
-		_, err := crawlDoc("rfrsh", path, nil, len(pkgs) > 0, time.Time{})
+		_, err := crawlDoc("rfrsh", importPath, nil, len(pkgs) > 0, time.Time{})
 		c <- err
 	}()
 	select {
@@ -408,13 +424,13 @@ func serveRefresh(resp http.ResponseWriter, req *http.Request) error {
 		err = errUpdateTimeout
 	}
 	if e, ok := err.(gosrc.NotFoundError); ok && e.Redirect != "" {
-		http.Redirect(resp, req, "/"+e.Redirect, http.StatusFound)
-		return nil
+		setFlashMessages(resp, []flashMessage{{ID: "redir", Args: []string{importPath}}})
+		importPath = e.Redirect
+		err = nil
+	} else if err != nil {
+		setFlashMessages(resp, []flashMessage{{ID: "refresh", Args: []string{errorText(err)}}})
 	}
-	if err != nil {
-		return err
-	}
-	http.Redirect(resp, req, "/"+path, http.StatusFound)
+	http.Redirect(resp, req, "/"+importPath, http.StatusFound)
 	return nil
 }
 
@@ -711,20 +727,24 @@ func (h apiHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	runHandler(resp, req, h, handleAPIError)
 }
 
+func errorText(err error) string {
+	if err == errUpdateTimeout {
+		return "Timeout getting package files from the version control system."
+	}
+	if e, ok := err.(*gosrc.RemoteError); ok {
+		return "Error getting package files from " + e.Host + "."
+	}
+	return "Internal server error."
+}
+
 func handleError(resp http.ResponseWriter, req *http.Request, status int, err error) {
 	switch status {
 	case http.StatusNotFound:
 		executeTemplate(resp, "notfound"+templateExt(req), status, nil, nil)
 	default:
-		s := http.StatusText(status)
-		if err == errUpdateTimeout {
-			s = "Timeout getting package files from the version control system."
-		} else if e, ok := err.(*gosrc.RemoteError); ok {
-			s = "Error getting package files from " + e.Host + "."
-		}
 		resp.Header().Set("Content-Type", textMIMEType)
 		resp.WriteHeader(http.StatusInternalServerError)
-		io.WriteString(resp, s)
+		io.WriteString(resp, errorText(err))
 	}
 }
 

--- a/gddo-server/template_test.go
+++ b/gddo-server/template_test.go
@@ -1,0 +1,33 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd.
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestFlashMessages(t *testing.T) {
+	resp := httptest.NewRecorder()
+
+	expectedMessages := []flashMessage{
+		{ID: "a", Args: []string{"one"}},
+		{ID: "b", Args: []string{"two", "three"}},
+		{ID: "c", Args: []string{}},
+	}
+
+	setFlashMessages(resp, expectedMessages)
+	req := &http.Request{Header: http.Header{"Cookie": {strings.Split(resp.Header().Get("Set-Cookie"), ";")[0]}}}
+
+	actualMessages := getFlashMessages(resp, req)
+	if !reflect.DeepEqual(actualMessages, expectedMessages) {
+		t.Errorf("got messages %+v, want %+v", actualMessages, expectedMessages)
+	}
+}


### PR DESCRIPTION
If the package import comment is specified and not equal to the current
path, then redirect to the path in the comment. See http://goo.gl/MBL1n6
for information about package import comments.