### PR TITLE
Improve handling of vendored packages, fix issues

### DIFF
--- a/database/index_test.go
+++ b/database/index_test.go
@@ -100,21 +100,30 @@ func TestDocTerms(t *testing.T) {
 	}
 }
 
-func TestExcludedPath(t *testing.T) {
-	tests := []struct {
-		path     string
-		expected bool
-	}{
-		{"code.google.com/p/go.text/internal/ucd", true},
-		{"code.google.com/p/go.text/internal", true},
-		{"camlistore.org/third_party/bazil.org/fuse", true},
-		{"bazil.org/fuse", false},
-	}
+var vendorPatTests = []struct {
+	path  string
+	match bool
+}{
+	{"camlistore.org/third_party/github.com/user/repo", true},
+	{"camlistore.org/third_party/dir", false},
+	{"camlistore.org/third_party", false},
+	{"camlistore.org/xthird_party/github.com/user/repo", false},
+	{"camlistore.org/third_partyx/github.com/user/repo", false},
 
-	for _, tt := range tests {
-		actual := isExcludedPath(tt.path)
-		if actual != tt.expected {
-			t.Errorf("isExcludedPath=%t, want %t for %s", actual, tt.expected, tt.path)
+	{"example.org/_third_party/github.com/user/repo/dir", true},
+	{"example.org/_third_party/dir", false},
+
+	{"github.com/user/repo/Godeps/_workspace/src/github.com/user/repo", true},
+	{"github.com/user/repo/Godeps/_workspace/src/dir", false},
+
+	{"github.com/user/repo", false},
+}
+
+func TestVendorPat(t *testing.T) {
+	for _, tt := range vendorPatTests {
+		match := vendorPat.MatchString(tt.path)
+		if match != tt.match {
+			t.Errorf("match(%q) = %v, want %v", tt.path, match, match)
 		}
 	}
 }

--- a/gddo-server/crawl.go
+++ b/gddo-server/crawl.go
@@ -8,23 +8,12 @@ package main
 
 import (
 	"log"
-	"regexp"
 	"strings"
 	"time"
 
 	"github.com/golang/gddo/doc"
 	"github.com/golang/gddo/gosrc"
 )
-
-var nestedProjectPat = regexp.MustCompile(`/(?:github\.com|launchpad\.net|code\.google\.com/p|bitbucket\.org|labix\.org)/`)
-
-func exists(path string) bool {
-	b, err := db.Exists(path)
-	if err != nil {
-		b = false
-	}
-	return b
-}
 
 // crawlDoc fetches the package documentation from the VCS and updates the database.
 func crawlDoc(source string, importPath string, pdoc *doc.Package, hasSubdirs bool, nextCrawl time.Time) (*doc.Package, error) {
@@ -61,9 +50,6 @@ func crawlDoc(source string, importPath string, pdoc *doc.Package, hasSubdirs bo
 		// Old import path for Go sub-repository.
 		pdoc = nil
 		err = gosrc.NotFoundError{Message: "old Go sub-repo", Redirect: "golang.org/x/" + importPath[len("code.google.com/p/go."):]}
-	} else if m := nestedProjectPat.FindStringIndex(importPath); m != nil && exists(importPath[m[0]+1:]) {
-		pdoc = nil
-		err = gosrc.NotFoundError{Message: "copy of other project."}
 	} else if blocked, e := db.IsBlocked(importPath); blocked && e == nil {
 		pdoc = nil
 		err = gosrc.NotFoundError{Message: "blocked."}

--- a/gosrc/path.go
+++ b/gosrc/path.go
@@ -15,7 +15,7 @@ import (
 )
 
 var validHost = regexp.MustCompile(`^[-a-z0-9]+(?:\.[-a-z0-9]+)+$`)
-var validPathElement = regexp.MustCompile(`^[-A-Za-z0-9~+][-A-Za-z0-9_.]*$`)
+var validPathElement = regexp.MustCompile(`^[-A-Za-z0-9~+_][-A-Za-z0-9_.]*$`)
 
 func isValidPathElement(s string) bool {
 	return validPathElement.MatchString(s) && s != "testdata"

--- a/gosrc/path_test.go
+++ b/gosrc/path_test.go
@@ -19,6 +19,7 @@ var goodImportPaths = []string{
 	"example.com/foo.git",
 	"launchpad.net/~user/foo/trunk",
 	"launchpad.net/~user/+junk/version",
+	"github.com/user/repo/_ok/x",
 }
 
 var badImportPaths = []string{
@@ -28,7 +29,6 @@ var badImportPaths = []string{
 	"favicon.ico",
 	"exmpple.com",
 	"github.com/user/repo/testdata/x",
-	"github.com/user/repo/_ignore/x",
 	"github.com/user/repo/.ignore/x",
 }
 


### PR DESCRIPTION
- Remove code that blocked vendored packages.
- Allow "_" at beginning of path element in package path. This had blocked package vendored by godeps.
- Compensate for previous two changes by improving the recognition and scoring of vendored packages.
- Fix issues #201, #195, #230 