### PR TITLE
Fix godoc.org homepage links

### DIFF
--- a/gddo-server/assets/templates/home.html
+++ b/gddo-server/assets/templates/home.html
@@ -27,10 +27,10 @@ and more.
       <li><a href="/-/index">Index</a>
       <li><a href="/-/go">Go Standard Packages</a>
       <li><a href="/-/subrepo">Go Sub-repository Packages</a>
-      <li><a href="https://code.google.com/p/go-wiki/wiki/Projects">Projects @ go-wiki</a>
-      <li><a href="https://github.com/search?o=desc&q=language%3Ago&s=stars&type=Repositories">Most stars</a>, 
-        <a href="https://github.com/search?o=desc&q=language%3Ago&s=forks&type=Repositories">most forks</a>, 
-        <a href="https://github.com/search?o=desc&q=language%3Ago&s=updated&type=Repositories">recently updated</a> on GitHub
+      <li><a href="https://golang.org/wiki/Projects">Projects @ go-wiki</a>
+      <li><a href="https://github.com/search?o=desc&amp;q=language%3Ago&amp;s=stars&amp;type=Repositories">Most stars</a>, 
+        <a href="https://github.com/search?o=desc&amp;q=language%3Ago&amp;s=forks&amp;type=Repositories">most forks</a>, 
+        <a href="https://github.com/search?o=desc&amp;q=language%3Ago&amp;s=updated&amp;type=Repositories">recently updated</a> on GitHub
     </ul>
   </div>
 </div>


### PR DESCRIPTION
- Change wiki link to new canonical link
- Change & to `&amp;` in links where applicable

Can be applied instead of #232 