### PR TITLE
Remove 'for range' for backwards compatibility

### DIFF
--- a/gosrc/client.go
+++ b/gosrc/client.go
@@ -115,7 +115,7 @@ func (c *httpClient) getFiles(urls []string, files []*File) error {
 			ch <- nil
 		}(i)
 	}
-	for range files {
+	for _ = range files {
 		if err := <-ch; err != nil {
 			return err
 		}


### PR DESCRIPTION
The previous code doesn't compile with go1.2.1, which is the current version in Ubuntu 14.04's repositories.  This change should fix that.