### PR TITLE
Remove code that blocks mirrors of the Go source.

### DIFF
--- a/gddo-server/crawl.go
+++ b/gddo-server/crawl.go
@@ -38,15 +38,7 @@ func crawlDoc(source string, importPath string, pdoc *doc.Package, hasSubdirs bo
 
 	start := time.Now()
 	var err error
-	if i := strings.Index(importPath, "/src/pkg/"); i > 0 && gosrc.IsGoRepoPath(importPath[i+len("/src/pkg/"):]) {
-		// Go source tree mirror.
-		pdoc = nil
-		err = gosrc.NotFoundError{Message: "Go source tree mirror."}
-	} else if i := strings.Index(importPath, "/libgo/go/"); i > 0 && gosrc.IsGoRepoPath(importPath[i+len("/libgo/go/"):]) {
-		// Go Frontend source tree mirror.
-		pdoc = nil
-		err = gosrc.NotFoundError{Message: "Go Frontend source tree mirror."}
-	} else if strings.HasPrefix(importPath, "code.google.com/p/go.") {
+	if strings.HasPrefix(importPath, "code.google.com/p/go.") {
 		// Old import path for Go sub-repository.
 		pdoc = nil
 		err = gosrc.NotFoundError{Message: "old Go sub-repo", Redirect: "golang.org/x/" + importPath[len("code.google.com/p/go."):]}


### PR DESCRIPTION
The code was not updated to the new directory tree hierarchy described
in golang.org/s/go14nopkg.

The code blocked repositories that were not mirrors of the Go source
tree. See issue #184. Updating the code to the new directory hierarchy
will likely create more false positives.

The admin tool can be used to manually block a mirror.

Fixes #184.