### PR TITLE
build package documentation against target architecture

### DIFF
--- a/doc/builder.go
+++ b/doc/builder.go
@@ -16,6 +16,7 @@ import (
 	"go/parser"
 	"go/token"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -456,6 +457,20 @@ var goEnvs = []struct{ GOOS, GOARCH string }{
 	{"linux", "amd64"},
 	{"darwin", "amd64"},
 	{"windows", "amd64"},
+}
+
+// Ensure each new package is parsed against target's architecture first.
+func init() {
+	var i int
+	for i = range goEnvs {
+		if goEnvs[i].GOOS == runtime.GOOS && goEnvs[i].GOARCH == runtime.GOARCH {
+			break
+		}
+	}
+	if i == 0 || i == len(goEnvs) {
+		return
+	}
+	goEnvs[0], goEnvs[i] = goEnvs[i], goEnvs[0]
 }
 
 func newPackage(dir *gosrc.Directory) (*Package, error) {


### PR DESCRIPTION
Currently `gddo-server` builds documentation for every package by importing it
against fixed list of platforms. The import is performed in a round-robin
manner - if importing with `goos=linux` fails, it tries to import with
the next platform from the list and so on until first success.

This change ensures runtime.GOOS is always first on the list, so
`gddo-server` always displays documentation for the current platform,
if a package happen to care.