### PR TITLE
Ignore metakey in keyboard shortcuts

### DIFF
--- a/gddo-server/assets/site.js
+++ b/gddo-server/assets/site.js
@@ -147,6 +147,10 @@ $(function() {
             return true;
         }
 
+        if (e.metaKey) {
+            return true;
+        }
+
         var ch = String.fromCharCode(e.which);
 
         if (combo) {


### PR DESCRIPTION
The F keyboard short blocked access to search in Safari. Fix by ignoring keyboard input when the metakey is pressed.