### PR TITLE
gddo-server: add -default_goos flag

### DIFF
--- a/doc/builder.go
+++ b/doc/builder.go
@@ -458,6 +458,29 @@ var goEnvs = []struct{ GOOS, GOARCH string }{
 	{"windows", "amd64"},
 }
 
+// SetDefaultGOOS sets given GOOS value as default one to use when building
+// package documents.
+func SetDefaultGOOS(goos string) {
+	if goos == "" {
+		return
+	}
+	var i int
+	for ; i < len(goEnvs); i++ {
+		if goEnvs[i].GOOS == goos {
+			break
+		}
+	}
+	switch i {
+	case 0:
+		return
+	case len(goEnvs):
+		env := goEnvs[0]
+		env.GOOS = goos
+		goEnvs = append(goEnvs, env)
+	}
+	goEnvs[0], goEnvs[i] = goEnvs[i], goEnvs[0]
+}
+
 func newPackage(dir *gosrc.Directory) (*Package, error) {
 
 	pkg := &Package{

--- a/gddo-server/main.go
+++ b/gddo-server/main.go
@@ -791,19 +791,21 @@ var (
 )
 
 var (
-	robot             = flag.Float64("robot", 100, "Request counter threshold for robots")
+	robot             = flag.Float64("robot", 100, "Request counter threshold for robots.")
 	assetsDir         = flag.String("assets", filepath.Join(defaultBase("github.com/golang/gddo/gddo-server"), "assets"), "Base directory for templates and static files.")
 	getTimeout        = flag.Duration("get_timeout", 8*time.Second, "Time to wait for package update from the VCS.")
 	firstGetTimeout   = flag.Duration("first_get_timeout", 5*time.Second, "Time to wait for first fetch of package from the VCS.")
 	maxAge            = flag.Duration("max_age", 24*time.Hour, "Update package documents older than this age.")
-	httpAddr          = flag.String("http", ":8080", "Listen for HTTP connections on this address")
+	httpAddr          = flag.String("http", ":8080", "Listen for HTTP connections on this address.")
 	sidebarEnabled    = flag.Bool("sidebar", false, "Enable package page sidebar.")
+	defaultGOOS       = flag.String("default_goos", "", "Default GOOS to use when building package documents.")
 	gitHubCredentials = ""
 	userAgent         = ""
 )
 
 func main() {
 	flag.Parse()
+	doc.SetDefaultGOOS(*defaultGOOS)
 	log.Printf("Starting server, os.Args=%s", strings.Join(os.Args, " "))
 
 	if err := parseHTMLTemplates([][]string{


### PR DESCRIPTION
gddo-server builds package document by trying to import it against
fixed list of GOOS values; by default it starts with Linux.

The -default_goos flag was added to provide different GOOS value to
start with.