### PR TITLE
Add "Refs" (find usages) links to definitions

### DIFF
--- a/gddo-server/assets/site.css
+++ b/gddo-server/assets/site.css
@@ -81,7 +81,13 @@ a.permalink {
     display: none;
 }
 
-h1:hover .permalink, h2:hover .permalink, h3:hover .permalink, h4:hover .permalink, h5:hover .permalink, h6:hover .permalink {
+a.refs {
+    display: none;
+    color: #666;
+    font-size: 0.8em;
+}
+
+h1:hover .permalink, h2:hover .permalink, h3:hover .permalink, h4:hover .permalink, h5:hover .permalink, h6:hover .permalink, h1:hover .refs, h2:hover .refs, h3:hover .refs, h4:hover .refs, h5:hover .refs, h6:hover .refs {
     display: inline;
 }
 

--- a/gddo-server/assets/templates/pkg.html
+++ b/gddo-server/assets/templates/pkg.html
@@ -113,7 +113,7 @@
             <h3 id="pkg-functions" class="section-header">Functions <a class="permalink" href="#pkg-functions">&para;</a></h3>
         {{end}}{{end}}
         {{range .Funcs}}
-          <h3 id="{{.Name}}" data-kind="f">func {{$.pdoc.SourceLink .Pos .Name .Name}} <a class="permalink" href="#{{.Name}}">&para;</a></h3>
+          <h3 id="{{.Name}}" data-kind="f">func {{$.pdoc.SourceLink .Pos .Name .Name}} <a class="permalink" href="#{{.Name}}">&para;</a> {{$.pdoc.RefsLink .Name}}</h3>
           <pre class="funcdecl">{{code .Decl nil}}</pre>{{.Doc|comment}}
           {{template "Examples" .|$.pdoc.ObjExamples}}
         {{end}}
@@ -124,20 +124,20 @@
         {{end}}{{end}}
 
         {{range $t := .Types}}
-          <h3 id="{{.Name}}" data-kind="t">type {{$.pdoc.SourceLink .Pos .Name .Name}} <a class="permalink" href="#{{.Name}}">&para;</a></h3>
+          <h3 id="{{.Name}}" data-kind="t">type {{$.pdoc.SourceLink .Pos .Name .Name}} <a class="permalink" href="#{{.Name}}">&para;</a> {{$.pdoc.RefsLink .Name}}</h3>
           <pre data-kind="{{if isInterface $t}}m{{else}}d{{end}}">{{code .Decl $t}}</pre>{{.Doc|comment}}
           {{range .Consts}}<pre data-kind="c">{{code .Decl nil}}</pre>{{.Doc|comment}}{{end}}
           {{range .Vars}}<pre data-kind="v">{{code .Decl nil}}</pre>{{.Doc|comment}}{{end}}
           {{template "Examples" .|$.pdoc.ObjExamples}}
 
           {{range .Funcs}}
-            <h4 id="{{.Name}}" data-kind="f">func {{$.pdoc.SourceLink .Pos .Name .Name}} <a class="permalink" href="#{{.Name}}">&para;</a></h4>
+            <h4 id="{{.Name}}" data-kind="f">func {{$.pdoc.SourceLink .Pos .Name .Name}} <a class="permalink" href="#{{.Name}}">&para;</a> {{$.pdoc.RefsLink .Name}}</h4>
             <pre class="funcdecl">{{code .Decl nil}}</pre>{{.Doc|comment}}
             {{template "Examples" .|$.pdoc.ObjExamples}}
           {{end}}
 
           {{range .Methods}}
-            <h4 id="{{$t.Name}}.{{.Name}}" data-kind="m">func ({{.Recv}}) {{$.pdoc.SourceLink .Pos .Name (printf "%s.%s" $t.Name .Name)}} <a class="permalink" href="#{{$t.Name}}.{{.Name}}">&para;</a></h4>
+            <h4 id="{{$t.Name}}.{{.Name}}" data-kind="m">func ({{.Recv}}) {{$.pdoc.SourceLink .Pos .Name (printf "%s.%s" $t.Name .Name)}} <a class="permalink" href="#{{$t.Name}}.{{.Name}}">&para;</a> {{$.pdoc.RefsLink $t.Name .Name}}</h4>
             <pre class="funcdecl">{{code .Decl nil}}</pre>{{.Doc|comment}}
             {{template "Examples" .|$.pdoc.ObjExamples}}
           {{end}}

--- a/gddo-server/template.go
+++ b/gddo-server/template.go
@@ -107,6 +107,12 @@ func (pdoc *tdoc) SourceLink(pos doc.Pos, text, anchor string) htemp.HTML {
 	return htemp.HTML(fmt.Sprintf(`<a title="View Source" href="%s">%s</a>`, u, text))
 }
 
+func (pdoc *tdoc) RefsLink(defParts ...string) htemp.HTML {
+	q := url.Values{"repo": []string{pdoc.ProjectRoot}, "pkg": []string{pdoc.ImportPath}, "def": []string{strings.Join(defParts, "/")}}
+	u := "https://sourcegraph.com/.godoc-refs?" + q.Encode()
+	return htemp.HTML(fmt.Sprintf(`<a class="refs" title="View References" href="%s">Refs</a>`, htemp.HTMLEscapeString(u)))
+}
+
 func (pdoc *tdoc) PageName() string {
 	if pdoc.Name != "" && !pdoc.IsCmd {
 		return pdoc.Name


### PR DESCRIPTION
This PR adds unobtrusive "Refs" links for each type, func, and method that show all references to the item (on Sourcegraph). Like the permalink, the Refs link is only displayed on hover.

Viewing usages of a definition is a good way to determine how (best) to use something, especially when the documentation is poor or nonexistent.

Possible improvements/changes:

* Fetch the reference count from the Sourcegraph API (either on the backend or on the client) and make the link read "Refs (123)" or "123 refs" instead of just "Refs"
* Find a way to add refs links for vars and consts (which don't have headers)

TODOs:

* [ ] (On Sourcegraph) Support all vanity Go import paths (currently only github.com, golang.org, and code.google.com import paths are supported)

Disclaimer: I'm one of the creators of Sourcegraph. I think lots of people would find it useful to view usages (and several people asked me to submit this), but I know it'd be a slippery slope to start adding external links to gddo. I'd obviously totally understand if this PR is rejected.

(As an aside, gowalker.org already offers links to examples on Sourcegraph; see [bytes.Buffer on gowalker.org](https://gowalker.org/bytes#Buffer), for example. They are quite popular, judging from our site analytics.)

------------------------

### Demo

* Go to http://gddotest.dev.sourcegraph.com/github.com/gorilla/mux#Route.Match

![image](https://cloud.githubusercontent.com/assets/1976/6764933/6a877684-cf85-11e4-8c93-707ae45308e9.png)

* Hover over the Match header and click [Refs](https://sourcegraph.com/.godoc-refs?def=Route%2FMatch&pkg=github.com%2Fgorilla%2Fmux&repo=github.com%2Fgorilla%2Fmux)

* You're taken to the Sourcegraph listing of references to the Match method

![image](https://cloud.githubusercontent.com/assets/1976/6764935/9324501c-cf85-11e4-9dbd-f53646d5ef74.png)