### PR TITLE
Link declarations to source

### DIFF
--- a/gddo-server/assets/site.css
+++ b/gddo-server/assets/site.css
@@ -42,14 +42,39 @@ pre {
     word-wrap: normal;
 }
 
-.funcdecl {
-  white-space: pre-wrap;
-  word-break: break-all;
-  word-wrap: break-word;
+.funcdecl > pre {
+    white-space: pre-wrap;
+    word-break: break-all;
+    word-wrap: break-word;
 }
 
 pre .com {
   color: rgb(147, 161, 161);
+}
+
+.decl {
+    position: relative;
+}
+
+.decl > a {
+    position: absolute;
+    top: 0px;
+    right: 0px;
+    display: none;
+    border: 1px solid #ccc;
+    border-top-right-radius: 4px;
+    border-bottom-left-radius: 4px;
+    padding-left: 4px;
+    padding-right: 4px;
+}
+
+.decl > a:hover {
+    background-color: white;
+    text-decoration: none;
+}
+
+.decl:hover > a {
+    display: block;
 }
 
 a, .navbar-default .navbar-brand {

--- a/gddo-server/assets/templates/common.html
+++ b/gddo-server/assets/templates/common.html
@@ -58,7 +58,7 @@
 {{define "PkgCmdFooter"}}
 <!-- Bugs -->
 {{with .pdoc}}{{with .Notes}}{{with .BUG}}
-  <h3 id="pkg-note-bug">Bugs <a class="permalink" href="#pkg-note-bug">&para;</a></h3>{{range .}}<p>{{$.pdoc.SourceLink .Pos "☞" ""}} {{.Body}}{{end}}
+  <h3 id="pkg-note-bug">Bugs <a class="permalink" href="#pkg-note-bug">&para;</a></h3>{{range .}}<p>{{$.pdoc.SourceLink .Pos "☞" true}} {{.Body}}{{end}}
 {{end}}{{end}}{{end}}
 
 {{if $.pkgs}}<h3 id="pkg-subdirectories">Directories <a class="permalink" href="#pkg-subdirectories">&para;</a></h3>

--- a/gddo-server/assets/templates/pkg.html
+++ b/gddo-server/assets/templates/pkg.html
@@ -99,13 +99,13 @@
         <!-- Contants -->
         {{if .Consts}}
           <h3 id="pkg-constants">Constants <a class="permalink" href="#pkg-constants">&para;</a></h3>
-          {{range .Consts}}<pre data-kind="c">{{code .Decl nil}}</pre>{{.Doc|comment}}{{end}}
+          {{range .Consts}}<div class="decl" data-kind="c">{{$.pdoc.SourceLink .Pos "\u2756" false}}{{code .Decl nil}}</div>{{.Doc|comment}}{{end}}
         {{end}}
 
         <!-- Variables -->
         {{if .Vars}}
           <h3 id="pkg-variables">Variables <a class="permalink" href="#pkg-variables">&para;</a></h3>
-          {{range .Vars}}<pre data-kind="v">{{code .Decl nil}}</pre>{{.Doc|comment}}{{end}}
+          {{range .Vars}}<div class="decl" data-kind="v">{{$.pdoc.SourceLink .Pos "\u2756" false}}{{code .Decl nil}}</div>{{.Doc|comment}}{{end}}
         {{end}}
 
         <!-- Functions -->
@@ -113,8 +113,8 @@
             <h3 id="pkg-functions" class="section-header">Functions <a class="permalink" href="#pkg-functions">&para;</a></h3>
         {{end}}{{end}}
         {{range .Funcs}}
-          <h3 id="{{.Name}}" data-kind="f">func {{$.pdoc.SourceLink .Pos .Name .Name}} <a class="permalink" href="#{{.Name}}">&para;</a></h3>
-          <pre class="funcdecl">{{code .Decl nil}}</pre>{{.Doc|comment}}
+          <h3 id="{{.Name}}" data-kind="f">func {{$.pdoc.SourceLink .Pos .Name true}} <a class="permalink" href="#{{.Name}}">&para;</a></h3>
+          <div class="funcdecl decl">{{$.pdoc.SourceLink .Pos "\u2756" false}}{{code .Decl nil}}</div>{{.Doc|comment}}
           {{template "Examples" .|$.pdoc.ObjExamples}}
         {{end}}
 
@@ -124,21 +124,21 @@
         {{end}}{{end}}
 
         {{range $t := .Types}}
-          <h3 id="{{.Name}}" data-kind="t">type {{$.pdoc.SourceLink .Pos .Name .Name}} <a class="permalink" href="#{{.Name}}">&para;</a></h3>
-          <pre data-kind="{{if isInterface $t}}m{{else}}d{{end}}">{{code .Decl $t}}</pre>{{.Doc|comment}}
-          {{range .Consts}}<pre data-kind="c">{{code .Decl nil}}</pre>{{.Doc|comment}}{{end}}
-          {{range .Vars}}<pre data-kind="v">{{code .Decl nil}}</pre>{{.Doc|comment}}{{end}}
+          <h3 id="{{.Name}}" data-kind="t">type {{$.pdoc.SourceLink .Pos .Name true}} <a class="permalink" href="#{{.Name}}">&para;</a></h3>
+          <div class="decl" data-kind="{{if isInterface $t}}m{{else}}d{{end}}">{{$.pdoc.SourceLink .Pos "\u2756" false}}{{code .Decl $t}}</div>{{.Doc|comment}}
+          {{range .Consts}}<div class="decl" data-kind="c">{{$.pdoc.SourceLink .Pos "\u2756" false}}{{code .Decl nil}}</div>{{.Doc|comment}}{{end}}
+          {{range .Vars}}<div class="decl" data-kind="v">{{$.pdoc.SourceLink .Pos "\u2756" false}}{{code .Decl nil}}</div>{{.Doc|comment}}{{end}}
           {{template "Examples" .|$.pdoc.ObjExamples}}
 
           {{range .Funcs}}
-            <h4 id="{{.Name}}" data-kind="f">func {{$.pdoc.SourceLink .Pos .Name .Name}} <a class="permalink" href="#{{.Name}}">&para;</a></h4>
-            <pre class="funcdecl">{{code .Decl nil}}</pre>{{.Doc|comment}}
+            <h4 id="{{.Name}}" data-kind="f">func {{$.pdoc.SourceLink .Pos .Name true}} <a class="permalink" href="#{{.Name}}">&para;</a></h4>
+            <div class="funcdecl decl">{{$.pdoc.SourceLink .Pos "\u2756" false}}{{code .Decl nil}}</div>{{.Doc|comment}}
             {{template "Examples" .|$.pdoc.ObjExamples}}
           {{end}}
 
           {{range .Methods}}
-            <h4 id="{{$t.Name}}.{{.Name}}" data-kind="m">func ({{.Recv}}) {{$.pdoc.SourceLink .Pos .Name (printf "%s.%s" $t.Name .Name)}} <a class="permalink" href="#{{$t.Name}}.{{.Name}}">&para;</a></h4>
-            <pre class="funcdecl">{{code .Decl nil}}</pre>{{.Doc|comment}}
+            <h4 id="{{$t.Name}}.{{.Name}}" data-kind="m">func ({{.Recv}}) {{$.pdoc.SourceLink .Pos .Name true}} <a class="permalink" href="#{{$t.Name}}.{{.Name}}">&para;</a></h4>
+            <div class="funcdecl decl">{{$.pdoc.SourceLink .Pos "\u2756" false}}{{code .Decl nil}}</div>{{.Doc|comment}}
             {{template "Examples" .|$.pdoc.ObjExamples}}
           {{end}}
         {{end}}

--- a/gddo-server/template.go
+++ b/gddo-server/template.go
@@ -92,19 +92,17 @@ func newTDoc(pdoc *doc.Package) *tdoc {
 	return &tdoc{Package: pdoc}
 }
 
-func (pdoc *tdoc) SourceLink(pos doc.Pos, text, anchor string) htemp.HTML {
-	text = htemp.HTMLEscapeString(text)
+func (pdoc *tdoc) SourceLink(pos doc.Pos, text string, textOnlyOK bool) htemp.HTML {
 	if pos.Line == 0 || pdoc.LineFmt == "" || pdoc.Files[pos.File].URL == "" {
-		return htemp.HTML(text)
+		if textOnlyOK {
+			return htemp.HTML(htemp.HTMLEscapeString(text))
+		} else {
+			return ""
+		}
 	}
-	var u string
-	if anchor != "" && strings.HasPrefix(pdoc.Files[pos.File].URL, "/") {
-		u = fmt.Sprintf("%s#%s", pdoc.Files[pos.File].URL, anchor)
-	} else {
-		u = fmt.Sprintf(pdoc.LineFmt, pdoc.Files[pos.File].URL, pos.Line)
-	}
-	u = htemp.HTMLEscapeString(u)
-	return htemp.HTML(fmt.Sprintf(`<a title="View Source" href="%s">%s</a>`, u, text))
+	return htemp.HTML(fmt.Sprintf(`<a title="View Source" href="%s">%s</a>`,
+		htemp.HTMLEscapeString(fmt.Sprintf(pdoc.LineFmt, pdoc.Files[pos.File].URL, pos.Line)),
+		htemp.HTMLEscapeString(text)))
 }
 
 func (pdoc *tdoc) PageName() string {
@@ -348,6 +346,7 @@ func codeFn(c doc.Code, typ *doc.Type) htemp.HTML {
 	var buf bytes.Buffer
 	last := 0
 	src := []byte(c.Text)
+	buf.WriteString("<pre>")
 	for _, a := range c.Annotations {
 		htemp.HTMLEscape(&buf, src[last:a.Pos])
 		switch a.Kind {
@@ -391,6 +390,7 @@ func codeFn(c doc.Code, typ *doc.Type) htemp.HTML {
 		last = int(a.End)
 	}
 	htemp.HTMLEscape(&buf, src[last:])
+	buf.WriteString("</pre>")
 	return htemp.HTML(buf.String())
 }
 


### PR DESCRIPTION
Link all declarations on package pages to the declaration in the source
code. The link is displayed in the top right corner of the \<pre> block
on hover over the \<pre>.

With this change, package pages now link to const and var declarations
in the source.

Function, type and method headings continue to link to the declaration
in the source.

Bonus change: delete remnants of an experiment from the tdoc SourceLink
method.

A demonstration of the feature is available at http://gary.burd.info/demo/.