### PR TITLE
Disable zoom when focusing search input on mobile Safari.

### DIFF
--- a/gddo-server/assets/site.css
+++ b/gddo-server/assets/site.css
@@ -85,3 +85,8 @@ h1:hover .permalink, h2:hover .permalink, h3:hover .permalink, h4:hover .permali
     display: inline;
 }
 
+@media (max-width : 768px) {
+    .form-control {
+        font-size:16px;
+    }
+}


### PR DESCRIPTION
## Before
![main-search-before](https://cloud.githubusercontent.com/assets/126417/7017872/b8b1fc2e-dd38-11e4-912e-91bf049d7a3b.png)
## After
![main-search-after](https://cloud.githubusercontent.com/assets/126417/7017870/b8b00e82-dd38-11e4-928a-fdd77e16435e.png)

http://stackoverflow.com/questions/2989263/disable-auto-zoom-in-input-text-tag-safari-on-iphone