### PR TITLE
support ssh:// for git

### DIFF
--- a/gosrc/vcs.go
+++ b/gosrc/vcs.go
@@ -97,7 +97,7 @@ type vcsCmd struct {
 
 var vcsCmds = map[string]*vcsCmd{
 	"git": {
-		schemes:  []string{"http", "https", "git"},
+		schemes:  []string{"http", "https", "ssh", "git"},
 		download: downloadGit,
 	},
 	"svn": {


### PR DESCRIPTION
Currently the vcs plugin would use git:// for running git ls-remote. I tried to use that and it always fail, and then it just work when I switch to ssh:// syntax.

This patch is to make ssh:// get supported. 