### PR TITLE
Add links to RFC sections, if available

### DIFF
--- a/gddo-server/template.go
+++ b/gddo-server/template.go
@@ -270,7 +270,7 @@ func importPathFn(path string) htemp.HTML {
 
 var (
 	h3Pat      = regexp.MustCompile(`<h3 id="([^"]+)">([^<]+)</h3>`)
-	rfcPat     = regexp.MustCompile(`RFC\s+(\d{3,4})`)
+	rfcPat     = regexp.MustCompile(`RFC\s+(\d{3,4})((,|)\s+[Ss]ection\s+(\d+)((\.\d+|)|)|)`)
 	packagePat = regexp.MustCompile(`\s+package\s+([-a-z0-9]\S+)`)
 )
 
@@ -309,6 +309,18 @@ func commentFn(v string) htemp.HTML {
 	p = replaceAll(p, rfcPat, func(out, src []byte, m []int) []byte {
 		out = append(out, `<a href="http://tools.ietf.org/html/rfc`...)
 		out = append(out, src[m[2]:m[3]]...)
+
+		// If available, add major section fragment
+		if m[6] != -1 {
+			out = append(out, `#section-`...)
+			out = append(out, src[m[8]:m[9]]...)
+
+			// If available, add minor section fragment
+			if m[13] != -1 {
+				out = append(out, src[m[12]:m[13]]...)
+			}
+		}
+
 		out = append(out, `">`...)
 		out = append(out, src[m[0]:m[1]]...)
 		out = append(out, `</a>`...)


### PR DESCRIPTION
This PR extends `rfcPat` to also match text such as: `RFC 3315, Section 17.2`, allowing easy linking to various RFC sections.

Here's the output of a quick test program I put together, with the new changes:

```
[zsh|matt@nerr-2]:~/tmp/gddo 0 % go run main.go
comments: 
// RFC 3315.
// RFC 3315 does some stuff
// RFC 3315 Section does
// RFC 3315 section 7.
// RFC 3315, Section 1.
// RFC 3315, Section 10.
// RFC 3315, Section 1.1.
// RFC 3315, Section 10.12345.
// RFC 3315, Section 10000.200.
 
output: <p>
// <a href="http://tools.ietf.org/html/rfc3315">RFC 3315</a>.
// <a href="http://tools.ietf.org/html/rfc3315">RFC 3315</a> does some stuff
// <a href="http://tools.ietf.org/html/rfc3315">RFC 3315</a> Section does
// <a href="http://tools.ietf.org/html/rfc3315#section-7">RFC 3315 section 7</a>.
// <a href="http://tools.ietf.org/html/rfc3315#section-1">RFC 3315, Section 1</a>.
// <a href="http://tools.ietf.org/html/rfc3315#section-10">RFC 3315, Section 10</a>.
// <a href="http://tools.ietf.org/html/rfc3315#section-1.1">RFC 3315, Section 1.1</a>.
// <a href="http://tools.ietf.org/html/rfc3315#section-10.12345">RFC 3315, Section 10.12345</a>.
// <a href="http://tools.ietf.org/html/rfc3315#section-10000.200">RFC 3315, Section 10000.200</a>.
</p>
<pre></pre>
```

And here's an example on a local `gddo-server` instance:

![selection060](https://cloud.githubusercontent.com/assets/1926905/8169256/6d10c880-1376-11e5-854d-5fb9e18bb850.png)
