### PR TITLE
Extend RFC regex to support multiple subsections

### DIFF
--- a/gddo-server/template.go
+++ b/gddo-server/template.go
@@ -270,7 +270,7 @@ func importPathFn(path string) htemp.HTML {
 
 var (
 	h3Pat      = regexp.MustCompile(`<h3 id="([^"]+)">([^<]+)</h3>`)
-	rfcPat     = regexp.MustCompile(`RFC\s+(\d{3,4})((,|)\s+[Ss]ection\s+(\d+)((\.\d+|)|)|)`)
+	rfcPat     = regexp.MustCompile(`RFC\s+(\d{3,4})(,?\s+[Ss]ection\s+(\d+(\.\d+)*))?`)
 	packagePat = regexp.MustCompile(`\s+package\s+([-a-z0-9]\S+)`)
 )
 
@@ -310,15 +310,10 @@ func commentFn(v string) htemp.HTML {
 		out = append(out, `<a href="http://tools.ietf.org/html/rfc`...)
 		out = append(out, src[m[2]:m[3]]...)
 
-		// If available, add major section fragment
-		if m[6] != -1 {
+		// If available, add section fragment
+		if m[4] != -1 {
 			out = append(out, `#section-`...)
-			out = append(out, src[m[8]:m[9]]...)
-
-			// If available, add minor section fragment
-			if m[13] != -1 {
-				out = append(out, src[m[12]:m[13]]...)
-			}
+			out = append(out, src[m[6]:m[7]]...)
 		}
 
 		out = append(out, `">`...)


### PR DESCRIPTION
My previous regex did not create links when multiple subsections were present, e.g. "RFC 4291, Section 2.5.1", as shown here (notice the trailing '1' is not highlighted):

![selection064](https://cloud.githubusercontent.com/assets/1926905/8415406/85751ef2-1e6c-11e5-9164-d5a0b77898cd.png)

This cleans up and extends the regex to support zero or more subsections, as shown after the patch:

![selection063](https://cloud.githubusercontent.com/assets/1926905/8415417/966ea32c-1e6c-11e5-9025-71fd1b2c5635.png)

Here is example output from this patch:

```
[zsh|matt@nerr-2]:~/go/tmp 0 % go run main.go 
2015/06/29 14:39:16 in: 
// foo
// RFC foo
// RFC 4291
// RFC 4291 section 1
// RFC 4291 section 10000
// RFC 4291, Section 2
// RFC 4291, Section 2.5
// RFC 4291, Section 2.5.1
// RFC 4291, Section 2.5.1.1.1.1

out: <p>
// foo
// RFC foo
// <a href="http://tools.ietf.org/html/rfc4291">RFC 4291</a>
// <a href="http://tools.ietf.org/html/rfc4291#section-1">RFC 4291 section 1</a>
// <a href="http://tools.ietf.org/html/rfc4291#section-10000">RFC 4291 section 10000</a>
// <a href="http://tools.ietf.org/html/rfc4291#section-2">RFC 4291, Section 2</a>
// <a href="http://tools.ietf.org/html/rfc4291#section-2.5">RFC 4291, Section 2.5</a>
// <a href="http://tools.ietf.org/html/rfc4291#section-2.5.1">RFC 4291, Section 2.5.1</a>
// <a href="http://tools.ietf.org/html/rfc4291#section-2.5.1.1.1.1">RFC 4291, Section 2.5.1.1.1.1</a>
</p>
```