### PR TITLE
gosrc: Use https to get list of valid TLDs.

### DIFF
--- a/gosrc/gen.go
+++ b/gosrc/gen.go
@@ -83,7 +83,7 @@ func main() {
 
 	// Get list of valid TLDs.
 
-	resp, err := http.Get("http://data.iana.org/TLD/tlds-alpha-by-domain.txt")
+	resp, err := http.Get("https://data.iana.org/TLD/tlds-alpha-by-domain.txt")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
It seems like a good idea to use https rather than http when fetching the list of TLDs.

I know it's only done at `go generate` time, but still.