### PR TITLE
Increase font contrast, use code highlighting theme of golang.org.

### DIFF
--- a/gddo-server/assets/site.css
+++ b/gddo-server/assets/site.css
@@ -31,11 +31,12 @@ h4 { margin-top: 20px; }
 code {
     background-color: inherit;
     border: none;
-    color: inherit;
+    color: #222;
     padding: 0;
 }
 
 pre {
+    color: #222;
     overflow: auto;
     white-space: pre;
     word-break: normal;
@@ -49,7 +50,7 @@ pre {
 }
 
 pre .com {
-  color: rgb(147, 161, 161);
+    color: #006600;
 }
 
 .decl {


### PR DESCRIPTION
Resolves #297.

Use green for comments. It's consistent with golang.org and has higher contrast (against background).

Use slightly darker black for code. It's consistent with golang.org and has higher contrast.

Before:

![image](https://cloud.githubusercontent.com/assets/1924134/9698503/17b3240e-536e-11e5-8031-2a302096b92f.png)

After:

![image](https://cloud.githubusercontent.com/assets/1924134/9698454/0d197838-536c-11e5-9e6a-6bd7ccf19c1e.png)