### PR TITLE
Replace backtick pairs in code comments with preformatted text

### DIFF
--- a/gddo-server/assets/site.css
+++ b/gddo-server/assets/site.css
@@ -35,6 +35,13 @@ code {
     padding: 0;
 }
 
+.fixed {
+    background-color: #f5f5f5;
+    border: 1px solid #ccc;
+    padding: 1px 3px;
+    white-space: pre;
+}
+
 pre {
     color: #222;
     overflow: auto;

--- a/gddo-server/template.go
+++ b/gddo-server/template.go
@@ -269,9 +269,10 @@ func importPathFn(path string) htemp.HTML {
 }
 
 var (
-	h3Pat      = regexp.MustCompile(`<h3 id="([^"]+)">([^<]+)</h3>`)
-	rfcPat     = regexp.MustCompile(`RFC\s+(\d{3,4})(,?\s+[Ss]ection\s+(\d+(\.\d+)*))?`)
-	packagePat = regexp.MustCompile(`\s+package\s+([-a-z0-9]\S+)`)
+	h3Pat        = regexp.MustCompile(`<h3 id="([^"]+)">([^<]+)</h3>`)
+	rfcPat       = regexp.MustCompile(`RFC\s+(\d{3,4})(,?\s+[Ss]ection\s+(\d+(\.\d+)*))?`)
+	packagePat   = regexp.MustCompile(`\s+package\s+([-a-z0-9]\S+)`)
+	preformatPat = regexp.MustCompile("`" + `(.*?)` + "`")
 )
 
 func replaceAll(src []byte, re *regexp.Regexp, replace func(out, src []byte, m []int) []byte) []byte {
@@ -335,6 +336,13 @@ func commentFn(v string) htemp.HTML {
 		out = append(out, src[m[2]+len(path):m[1]]...)
 		return out
 	})
+	p = replaceAll(p, preformatPat, func(out, src []byte, m []int) []byte {
+		out = append(out, `<code class="fixed">`...)
+		out = append(out, bytes.Trim(src[m[0]:m[1]], "`")...)
+		out = append(out, `</code>`...)
+		return out
+	})
+
 	return htemp.HTML(p)
 }
 


### PR DESCRIPTION
Enables use of the common Markdown backtick notation for displaying commands and identifiers with preformatted text, like: `ip addr show dev eth0`.

Example before this change: https://godoc.org/github.com/vishvananda/netlink#AddrAdd

Example after:

![selection075](https://cloud.githubusercontent.com/assets/1926905/9969454/a090f7fc-5e1c-11e5-964c-ec43e994a0ea.png)

It's also worth noting that these preformatted text blocks do not wrap lines at the moment:

![selection076](https://cloud.githubusercontent.com/assets/1926905/9969538/0aed217a-5e1d-11e5-92f2-5a077581a7cb.png)

Please feel free to suggest CSS corrections or improvements.  I haven't written CSS in a very long time and mostly just copied the style from existing preformatted blocks.

/cc @adg @shurcooL 