### PR TITLE
enforce HTTPS

### DIFF
--- a/gddo-server/https.go
+++ b/gddo-server/https.go
@@ -1,0 +1,19 @@
+package main
+
+import "net/http"
+
+type httpsEnforcerHandler struct {
+	h http.Handler
+}
+
+func (h httpsEnforcerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Host == "godoc.org" {
+		w.Header().Add("Strict-Transport-Security", "max-age=631138519; includeSubdomains; preload")
+		if r.Header.Get("X-Scheme") != "https" {
+			r.URL.Scheme = "https"
+			http.Redirect(w, r, r.URL.String(), http.StatusFound)
+			return
+		}
+	}
+	h.h.ServeHTTP(w, r)
+}

--- a/gddo-server/main.go
+++ b/gddo-server/main.go
@@ -898,7 +898,11 @@ func main() {
 
 	cacheBusters.Handler = mux
 
-	if err := http.ListenAndServe(*httpAddr, hostMux{{"api.", apiMux}, {"", mux}}); err != nil {
+	allMux := httpsEnforcerHandler{
+		hostMux{{"api.", apiMux}, {"", mux}},
+	}
+
+	if err := http.ListenAndServe(*httpAddr, allMux); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
Redirect HTTP links to HTTPS and set HSTS correctly.

This is specific to the godoc.org set up (with nginx passing a X-Scheme header back) and without fixing up api.godoc.org.

Fixes #304.