### PR TITLE
go-talks understand more complicated URLs

### DIFF
--- a/gosrc/bitbucket.go
+++ b/gosrc/bitbucket.go
@@ -15,7 +15,7 @@ import (
 
 func init() {
 	addService(&service{
-		pattern: regexp.MustCompile(`^bitbucket\.org/(?P<owner>[a-z0-9A-Z_.\-]+)/(?P<repo>[a-z0-9A-Z_.\-]+)(?P<dir>/[a-z0-9A-Z_.\-/]*)?$`),
+		pattern: regexp.MustCompile(`^bitbucket\.org/(?P<owner>[^/]+)/(?P<repo>[^/]+)(?P<dir>/.*)?$`),
 		prefix:  "bitbucket.org/",
 		get:     getBitbucketDir,
 	})

--- a/gosrc/bitbucket.go
+++ b/gosrc/bitbucket.go
@@ -15,7 +15,7 @@ import (
 
 func init() {
 	addService(&service{
-		pattern: regexp.MustCompile(`^bitbucket\.org/(?P<owner>[^/]+)/(?P<repo>[^/]+)(?P<dir>/.*)?$`),
+		pattern: regexp.MustCompile(`^bitbucket\.org/(?P<owner>[^/]+)/(?P<repo>[^/]+)(?P<dir>/[a-z0-9A-Z_.\-/]*)?$`),
 		prefix:  "bitbucket.org/",
 		get:     getBitbucketDir,
 	})

--- a/gosrc/github.go
+++ b/gosrc/github.go
@@ -18,7 +18,7 @@ import (
 
 func init() {
 	addService(&service{
-		pattern:         regexp.MustCompile(`^github\.com/(?P<owner>[a-z0-9A-Z_.\-]+)/(?P<repo>[a-z0-9A-Z_.\-]+)(?P<dir>/[a-z0-9A-Z_.\-/]*)?$`),
+		pattern:         regexp.MustCompile(`^github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)(?P<dir>/.*)?$`),
 		prefix:          "github.com/",
 		get:             getGitHubDir,
 		getPresentation: getGitHubPresentation,
@@ -26,7 +26,7 @@ func init() {
 	})
 
 	addService(&service{
-		pattern: regexp.MustCompile(`^gist\.github\.com/(?P<gist>[a-z0-9A-Z_.\-]+)\.git$`),
+		pattern: regexp.MustCompile(`^gist\.github\.com/(?P<gist>.+)\.git$`),
 		prefix:  "gist.github.com/",
 		get:     getGistDir,
 	})

--- a/gosrc/github.go
+++ b/gosrc/github.go
@@ -18,7 +18,7 @@ import (
 
 func init() {
 	addService(&service{
-		pattern:         regexp.MustCompile(`^github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)(?P<dir>/.*)?$`),
+		pattern:         regexp.MustCompile(`^github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)(?P<dir>/[a-z0-9A-Z_.\-/]*)?$`),
 		prefix:          "github.com/",
 		get:             getGitHubDir,
 		getPresentation: getGitHubPresentation,

--- a/gosrc/google.go
+++ b/gosrc/google.go
@@ -16,7 +16,7 @@ import (
 
 func init() {
 	addService(&service{
-		pattern:         regexp.MustCompile(`^code\.google\.com/(?P<pr>[pr])/(?P<repo>[a-z0-9\-]+)(:?\.(?P<subrepo>[a-z0-9\-]+))?(?P<dir>/[a-z0-9A-Z_.\-/]+)?$`),
+		pattern:         regexp.MustCompile(`^code\.google\.com/(?P<pr>[pr])/(?P<repo>[^/]+)(:?\.(?P<subrepo>[^/]+))?(?P<dir>/.+)?$`),
 		prefix:          "code.google.com/",
 		get:             getGoogleDir,
 		getPresentation: getGooglePresentation,

--- a/gosrc/google.go
+++ b/gosrc/google.go
@@ -16,7 +16,7 @@ import (
 
 func init() {
 	addService(&service{
-		pattern:         regexp.MustCompile(`^code\.google\.com/(?P<pr>[pr])/(?P<repo>[^/]+)(:?\.(?P<subrepo>[^/]+))?(?P<dir>/.+)?$`),
+-		pattern:         regexp.MustCompile(`^code\.google\.com/(?P<pr>[pr])/(?P<repo>[a-z0-9\-]+)(:?\.(?P<subrepo>[a-z0-9\-]+))?(?P<dir>/[a-z0-9A-Z_.\-/]+)?$`),
 		prefix:          "code.google.com/",
 		get:             getGoogleDir,
 		getPresentation: getGooglePresentation,

--- a/gosrc/gosrc_test.go
+++ b/gosrc/gosrc_test.go
@@ -194,7 +194,7 @@ func (t testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, nil
 }
 
-var githubPattern = regexp.MustCompile(`^github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)(?P<dir>/.*)?$`)
+var githubPattern = regexp.MustCompile(`^github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)(?P<dir>/[a-z0-9A-Z_.\-/]*)?$`)
 
 func testGet(client *http.Client, match map[string]string, etag string) (*Directory, error) {
 	importPath := match["importPath"]

--- a/gosrc/gosrc_test.go
+++ b/gosrc/gosrc_test.go
@@ -194,7 +194,7 @@ func (t testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, nil
 }
 
-var githubPattern = regexp.MustCompile(`^github\.com/(?P<owner>[a-z0-9A-Z_.\-]+)/(?P<repo>[a-z0-9A-Z_.\-]+)(?P<dir>/[a-z0-9A-Z_.\-/]*)?$`)
+var githubPattern = regexp.MustCompile(`^github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)(?P<dir>/.*)?$`)
 
 func testGet(client *http.Client, match map[string]string, etag string) (*Directory, error) {
 	importPath := match["importPath"]

--- a/gosrc/launchpad.go
+++ b/gosrc/launchpad.go
@@ -22,7 +22,7 @@ import (
 
 func init() {
 	addService(&service{
-		pattern: regexp.MustCompile(`^launchpad\.net/(?P<repo>(?P<project>[^/]+)(?P<series>/[^/]+)?|~[^/]+/(\+junk|[^/]+)/[^/]+)(?P<dir>/.+)*$`),
+-		pattern: regexp.MustCompile(`^launchpad\.net/(?P<repo>(?P<project>[^/]+)(?P<series>/[a-z0-9A-Z_.\-]+)?|~[a-z0-9A-Z_.\-]+/(\+junk|[a-z0-9A-Z_.\-]+)/[a-z0-9A-Z_.\-]+)(?P<dir>/[a-z0-9A-Z_.\-/]+)*$`),
 		prefix:  "launchpad.net/",
 		get:     getLaunchpadDir,
 	})

--- a/gosrc/launchpad.go
+++ b/gosrc/launchpad.go
@@ -22,7 +22,7 @@ import (
 
 func init() {
 	addService(&service{
-		pattern: regexp.MustCompile(`^launchpad\.net/(?P<repo>(?P<project>[a-z0-9A-Z_.\-]+)(?P<series>/[a-z0-9A-Z_.\-]+)?|~[a-z0-9A-Z_.\-]+/(\+junk|[a-z0-9A-Z_.\-]+)/[a-z0-9A-Z_.\-]+)(?P<dir>/[a-z0-9A-Z_.\-/]+)*$`),
+		pattern: regexp.MustCompile(`^launchpad\.net/(?P<repo>(?P<project>[^/]+)(?P<series>/[^/]+)?|~[^/]+/(\+junk|[^/]+)/[^/]+)(?P<dir>/.+)*$`),
 		prefix:  "launchpad.net/",
 		get:     getLaunchpadDir,
 	})


### PR DESCRIPTION
original regexp patter("[a-z0-9A-Z_.\-]+") very strict for URLs
change it to "[^/]", match more URLs

fixed #293