### PR TITLE
Fix example code double-div rendering regression.

### DIFF
--- a/gddo-server/assets/templates/pkg.html
+++ b/gddo-server/assets/templates/pkg.html
@@ -178,7 +178,7 @@
         <div id="ex-{{.ID}}" class="panel-collapse collapse"><div class="panel-body">
           {{with .Example.Doc}}<p>{{.|comment}}{{end}}
           <p>Code:{{if .Example.Play}}<span class="pull-right"><a href="?play={{.ID}}">play</a>&nbsp;</span>{{end}}
-          <pre>{{code .Example.Code nil}}</pre>
+          {{code .Example.Code nil}}
           {{with .Example.Output}}<p>Output:<pre>{{.}}</pre>{{end}}
         </div></div>
       </div>


### PR DESCRIPTION
In c494ad61ef94b75ade6cb39ec22031df3959c5ea (/cc @garyburd), `codeFn` was refactored to additionally write `<pre>` and `</pre>`. Most of the instances of `{{code ...}}` in templates were updated accordingly, but this one was missed.

As a result, after that commit, the example was written with a double-div.

As an example, see https://godoc.org/net/http#example-FileServer.

Before this fix:

![image](https://cloud.githubusercontent.com/assets/1924134/10120046/b38d7d06-645e-11e5-9c69-9d43e7247109.png)

```HTML
<pre><pre><span class="com">// Simple static webserver:</span>
log.Fatal(http.ListenAndServe(":8080", http.FileServer(http.Dir("/usr/share/doc"))))
</pre></pre>
```

After this fix:

![image](https://cloud.githubusercontent.com/assets/1924134/10120052/ceae0916-645e-11e5-85a2-d74b200ec0e7.png)

```HTML
<pre><span class="com">// Simple static webserver:</span>
log.Fatal(http.ListenAndServe(":8080", http.FileServer(http.Dir("/usr/share/doc"))))
</pre>
```