### PR TITLE
redirect code.google.com/p/go.* to golang.org

### DIFF
--- a/gddo-server/crawl.go
+++ b/gddo-server/crawl.go
@@ -41,11 +41,7 @@ func crawlDoc(source string, importPath string, pdoc *doc.Package, hasSubdirs bo
 
 	start := time.Now()
 	var err error
-	if strings.HasPrefix(importPath, "code.google.com/p/go.") {
-		// Old import path for Go sub-repository.
-		pdoc = nil
-		err = gosrc.NotFoundError{Message: "old Go sub-repo", Redirect: "golang.org/x/" + importPath[len("code.google.com/p/go."):]}
-	} else if blocked, e := db.IsBlocked(importPath); blocked && e == nil {
+	if blocked, e := db.IsBlocked(importPath); blocked && e == nil {
 		pdoc = nil
 		err = gosrc.NotFoundError{Message: "blocked."}
 	} else if testdataPat.MatchString(importPath) {

--- a/gosrc/google.go
+++ b/gosrc/google.go
@@ -20,6 +20,7 @@ func init() {
 		prefix:          "code.google.com/",
 		get:             getGoogleDir,
 		getPresentation: getGooglePresentation,
+		checkRedirect:   checkGoogleRedirect,
 	})
 }
 
@@ -28,7 +29,29 @@ var (
 	googleRevisionRe = regexp.MustCompile(`<h2>(?:[^ ]+ - )?Revision *([^:]+):`)
 	googleEtagRe     = regexp.MustCompile(`^(hg|git|svn)-`)
 	googleFileRe     = regexp.MustCompile(`<li><a href="([^"]+)"`)
+	googleRedirctMap = []struct {
+		oldRepo string
+		newRepo string
+	}{
+		{"code.google.com/p/go.tools/godoc/static", "golang.org/x/playground/app/static"},
+		{"code.google.com/p/go.tools/playground", "golang.org/x/playground"},
+		{"code.google.com/p/go.talks/present", "golang.org/x/tools/present"},
+		{"code.google.com/p/go.example", "github.com/golang/example"},
+		{"code.google.com/p/go.", "golang.org/x/"},
+	}
 )
+
+//check repo if redirect
+func checkGoogleRedirect(importPath string) (newRepo string, ok bool) {
+	for _, v := range googleRedirctMap {
+		if strings.HasPrefix(importPath, v.oldRepo) {
+			newRepo = v.newRepo + importPath[len(v.oldRepo):]
+			ok = true
+			break
+		}
+	}
+	return
+}
 
 func getGoogleDir(client *http.Client, match map[string]string, savedEtag string) (*Directory, error) {
 	c := &httpClient{client: client}

--- a/gosrc/gosrc_test.go
+++ b/gosrc/gosrc_test.go
@@ -270,3 +270,17 @@ func TestGetDynamic(t *testing.T) {
 		}
 	}
 }
+func TestGoSubRepoRedirect(t *testing.T) {
+	for oldRepo, newRepo := range map[string]string{
+		"code.google.com/p/go.tools/cmd/cover":    "golang.org/x/tools/cmd/cover",
+		"code.google.com/p/go.talks/present":      "golang.org/x/tools/present",
+		"code.google.com/p/go.tools/godoc/static": "golang.org/x/playground/app/static",
+		"code.google.com/p/go.tools/playground":   "golang.org/x/playground",
+		"code.google.com/p/go.example":            "github.com/golang/example",
+	} {
+		_, err := Get(http.DefaultClient, oldRepo, "")
+		if e, ok := err.(NotFoundError); !ok || e.Redirect != newRepo {
+			t.Fatalf("got %s, want %s", e.Redirect, newRepo)
+		}
+	}
+}


### PR DESCRIPTION
redirect code.google.com/p/go.* to golang.org
as code.google.com will shut down finally, but some package still
remains in some old articles. I have found some in blog.golang.org
(https://groups.google.com/forum/#!topic/golang-dev/tQ_iKZeu5_w).

this commit redirect golang offical repo on Google code to their new
home.