### PR TITLE
fixed_github_url_parse

### DIFF
--- a/gosrc/github.go
+++ b/gosrc/github.go
@@ -18,7 +18,7 @@ import (
 
 func init() {
 	addService(&service{
-		pattern:         regexp.MustCompile(`^github\.com/(?P<owner>[a-z0-9A-Z_.\-]+)/(?P<repo>[a-z0-9A-Z_.\-]+)(?P<dir>/[a-z0-9A-Z_.\-/]*)?$`),
+		pattern:         regexp.MustCompile(`^github\.com/(?P<owner>[a-z0-9A-Z_.\-]+)/(?P<repo>[a-z0-9A-Z_.\-]+)(?P<dir>/[^/]*)?$`),
 		prefix:          "github.com/",
 		get:             getGitHubDir,
 		getPresentation: getGitHubPresentation,


### PR DESCRIPTION
original regexp patter("[a-z0-9A-Z_.\-]+") very strict for URLs
change it to "[^/]", match more URLs.

only change github regexp for safe, but other have the same question.

fixed #293