### PR TITLE
Display flash messages on not found page

### DIFF
--- a/gddo-server/assets/templates/notfound.html
+++ b/gddo-server/assets/templates/notfound.html
@@ -1,6 +1,7 @@
 {{define "Head"}}<title>Not Found - GoDoc</title>{{end}}
 
 {{define "Body"}}
+  {{template "FlashMessages" .flashMessages}}
   <h1>Not Found</h1>
   <p>Oh snap! Our team of gophers could not find the web page you are looking for. Try one of these pages:
   <ul>

--- a/gddo-server/main.go
+++ b/gddo-server/main.go
@@ -745,7 +745,9 @@ func errorText(err error) string {
 func handleError(resp http.ResponseWriter, req *http.Request, status int, err error) {
 	switch status {
 	case http.StatusNotFound:
-		executeTemplate(resp, "notfound"+templateExt(req), status, nil, nil)
+		executeTemplate(resp, "notfound"+templateExt(req), status, nil, map[string]interface{}{
+			"flashMessages": getFlashMessages(resp, req),
+		})
 	default:
 		resp.Header().Set("Content-Type", textMIMEType)
 		resp.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
The reqeust godoc.org/golang.org/x/talks/present redirects with a flash
message to godoc.org/golang.org/x/talks/present. This page is not found.

This change updates the "not found" template to display the flash message.
Previous to this change, the flash message was displayed the next time
the use visited a regular package page.

The code should be updated to display flash messages on every page, but that's a much bigger change.