### PR TITLE
Handle Google Project Hosting redirects

### DIFF
--- a/gosrc/client.go
+++ b/gosrc/client.go
@@ -30,6 +30,7 @@ func (c *httpClient) err(resp *http.Response) error {
 	return &RemoteError{resp.Request.URL.Host, fmt.Errorf("%d: (%s)", resp.StatusCode, resp.Request.URL.String())}
 }
 
+// get issues a GET to the specified URL.
 func (c *httpClient) get(url string) (*http.Response, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -39,6 +40,26 @@ func (c *httpClient) get(url string) (*http.Response, error) {
 		req.Header[k] = vs
 	}
 	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, &RemoteError{req.URL.Host, err}
+	}
+	return resp, err
+}
+
+// getNoFollow issues a GET to the specified URL without following redirects.
+func (c *httpClient) getNoFollow(url string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	for k, vs := range c.header {
+		req.Header[k] = vs
+	}
+	t := c.client.Transport
+	if t == nil {
+		t = http.DefaultTransport
+	}
+	resp, err := t.RoundTrip(req)
 	if err != nil {
 		return nil, &RemoteError{req.URL.Host, err}
 	}

--- a/gosrc/print.go
+++ b/gosrc/print.go
@@ -44,8 +44,10 @@ func printDir(path string) {
 		gosrc.SetLocalDevMode(*local)
 	}
 	dir, err := gosrc.Get(http.DefaultClient, path, *etag)
-	if err != nil {
-		log.Fatal(err)
+	if e, ok := err.(gosrc.NotFoundError); ok && e.Redirect != "" {
+		log.Fatalf("redirect to %s", e.Redirect)
+	} else if err != nil {
+		log.Fatalf("%+v", err)
 	}
 
 	fmt.Println("ImportPath    ", dir.ImportPath)


### PR DESCRIPTION
If the owner of a project on Google Project Hosting configured a
redirect to another service, then redirect the corresponding pages on
godoc.org.

Examples of redirected packags are:

    code.google.com/p/gocc -> github.com/goccmack/gocc
    code.google.com/p/vitess/go/bson -> github.com/youtube/vitess/go/bson