### PR TITLE
Adding files section to the bottom of command pages

### DIFF
--- a/gddo-server/assets/templates/cmd.html
+++ b/gddo-server/assets/templates/cmd.html
@@ -4,5 +4,6 @@
   {{template "ProjectNav" $}}
   <h2>Command {{$.pdoc.PageName}}</h2>
   {{$.pdoc.Doc|comment}}
+  {{template "PkgFiles" $}}
   {{template "PkgCmdFooter" $}}
 {{end}}

--- a/gddo-server/assets/templates/common.html
+++ b/gddo-server/assets/templates/common.html
@@ -23,11 +23,14 @@
 {{define "ProjectNav"}}{{template "FlashMessages" .flashMessages}}<div class="clearfix" id="x-projnav">
   {{if .pdoc.ProjectRoot}}{{if .pdoc.ProjectURL}}<a href="{{.pdoc.ProjectURL}}"><strong>{{.pdoc.ProjectName}}:</strong></a>{{else}}<strong>{{.pdoc.ProjectName}}:</strong>{{end}}{{else}}<a href="/-/go">Go:</a>{{end}}
   {{.pdoc.Breadcrumbs templateName}}
-  {{if and .pdoc.Name (equal templateName "pkg.html")}}
+  {{if and .pdoc.Name (or templateName "pkg.html" templateName "cmd.html")}}
   <span class="pull-right">
-    <a href="#pkg-index">Index</a>
-    {{if .pdoc.AllExamples}}<span class="text-muted">|</span> <a href="#pkg-examples">Examples</a>{{end}}
-    <span class="text-muted">|</span> <a href="#pkg-files">Files</a>
+    {{if not .pdoc.IsCmd}}
+      <a href="#pkg-index">Index</a>
+      {{if .pdoc.AllExamples}}<span class="text-muted">|</span> <a href="#pkg-examples">Examples</a>{{end}}
+      <span class="text-muted">|</span>
+    {{end}}
+    <a href="#pkg-files">Files</a>
     {{if .pkgs}}<span class="text-muted">|</span> <a href="#pkg-subdirectories">Directories</a>{{end}}
   </span>
   {{end}}
@@ -53,6 +56,15 @@
     <meta name="twitter:site" content="@golang">
   {{end}}
   {{if .Errors}}<meta name="robots" content="NOINDEX">{{end}}
+{{end}}{{end}}
+
+{{define "PkgFiles"}}{{with .pdoc}}
+<h4 id="pkg-files">
+  {{with .BrowseURL}}<a href="{{.}}">Package Files</a>{{else}}Package Files{{end}}
+  <a class="permalink" href="#pkg-files">&para;</a>
+</h4>
+
+<p>{{range .Files}}{{if .URL}}<a href="{{.URL}}">{{.Name}}</a>{{else}}{{.Name}}{{end}} {{end}}</p>
 {{end}}{{end}}
 
 {{define "PkgCmdFooter"}}

--- a/gddo-server/assets/templates/pkg.html
+++ b/gddo-server/assets/templates/pkg.html
@@ -89,13 +89,7 @@
         {{end}}
 
         <!-- Files -->
-        <h4 id="pkg-files">
-          {{with .BrowseURL}}<a href="{{.}}">Package Files</a>{{else}}Package Files{{end}}
-          <a class="permalink" href="#pkg-files">&para;</a>
-        </h4>
-
-        <p>{{range .Files}}{{if .URL}}<a href="{{.URL}}">{{.Name}}</a>{{else}}{{.Name}}{{end}} {{end}}</p>
-
+        {{template "PkgFiles" $}}
         <!-- Contants -->
         {{if .Consts}}
           <h3 id="pkg-constants">Constants <a class="permalink" href="#pkg-constants">&para;</a></h3>


### PR DESCRIPTION
Based on the discussion on https://github.com/golang/gddo/issues/314. Creating this PR so that the files section is visible at the bottom of command pages as well.

Fixes https://github.com/golang/gddo/issues/314