### PR TITLE
fix github regexp: allow more than 1 directory deep in the repo

### DIFF
--- a/gosrc/github.go
+++ b/gosrc/github.go
@@ -18,7 +18,7 @@ import (
 
 func init() {
 	addService(&service{
-		pattern:         regexp.MustCompile(`^github\.com/(?P<owner>[a-z0-9A-Z_.\-]+)/(?P<repo>[a-z0-9A-Z_.\-]+)(?P<dir>/[^/]*)?$`),
+		pattern:         regexp.MustCompile(`^github\.com/(?P<owner>[a-z0-9A-Z_.\-]+)/(?P<repo>[a-z0-9A-Z_.\-]+)(?P<dir>/.*)?$`),
 		prefix:          "github.com/",
 		get:             getGitHubDir,
 		getPresentation: getGitHubPresentation,

--- a/gosrc/path_test.go
+++ b/gosrc/path_test.go
@@ -36,7 +36,15 @@ func TestIsValidRemotePath(t *testing.T) {
 		if !IsValidRemotePath(importPath) {
 			t.Errorf("isBadImportPath(%q) -> true, want false", importPath)
 		}
+
+		for _, s := range services {
+			if _, err := s.match(importPath); err != nil {
+				t.Errorf("match(%#v) → error %v", importPath, err)
+				break
+			}
+		}
 	}
+
 	for _, importPath := range badImportPaths {
 		if IsValidRemotePath(importPath) {
 			t.Errorf("isBadImportPath(%q) -> false, want true", importPath)


### PR DESCRIPTION
Fixes #340

I've adapted the unit test from gosrc.go::getStatic.