### PR TITLE
doc: Add "linux", "js" GOOS-GOARCH env pair.

### DIFF
--- a/doc/builder.go
+++ b/doc/builder.go
@@ -456,6 +456,7 @@ var goEnvs = []struct{ GOOS, GOARCH string }{
 	{"linux", "amd64"},
 	{"darwin", "amd64"},
 	{"windows", "amd64"},
+	{"linux", "js"},
 }
 
 // SetDefaultGOOS sets given GOOS value as default one to use when building


### PR DESCRIPTION
Resolves #342.

There is a Go compiler (named GopherJS) that targets environments where only JavaScript can run. Its GOARCH value is "js". Adding a "linux", "js" GOOS-GOARCH env pair allows gddo to display Go packages that are targeting js environments only.

See https://github.com/golang/gddo/issues/342#issuecomment-149797379 for full motivation and additional details, examples of such packages that currently exist.

/cc @adg