### PR TITLE
Use official jQuery CDN

### DIFF
--- a/gddo-server/assets/templates/common.html
+++ b/gddo-server/assets/templates/common.html
@@ -88,7 +88,7 @@
 
 {{define "Bootstrap.css"}}<link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css" rel="stylesheet">{{end}}
 {{define "Bootstrap.js"}}<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>{{end}}
-{{define "jQuery"}}<script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>{{end}}
+{{define "jQuery"}}<script src="//code.jquery.com/jquery-2.0.3.min.js"></script>{{end}}
 
 {{define "FlashMessages"}}{{range .}}
   {{if eq .ID "redir"}}{{if eq (len .Args) 1}}<div class="alert alert-warning">Redirected from {{index .Args 0}}.</div>{{end}}

--- a/gddo-server/main.go
+++ b/gddo-server/main.go
@@ -918,7 +918,7 @@ func main() {
 	mux.Handle("/robots.txt", staticServer.FileHandler("robots.txt"))
 	mux.Handle("/BingSiteAuth.xml", staticServer.FileHandler("BingSiteAuth.xml"))
 	mux.Handle("/C", http.RedirectHandler("http://golang.org/doc/articles/c_go_cgo.html", http.StatusMovedPermanently))
-	mux.Handle("/ajax.googleapis.com/", http.NotFoundHandler())
+	mux.Handle("/code.jquery.com/", http.NotFoundHandler())
 	mux.Handle("/", handler(serveHome))
 
 	cacheBusters.Handler = mux


### PR DESCRIPTION
I it seems like ajax.googleapis.com is blocked in China, so we replace the CDN with the official jQuery CDN.

Fixes #346