### PR TITLE
gosrc: Use import path as clone URL for git clone/ls-remote.

### DIFF
--- a/gosrc/vcs.go
+++ b/gosrc/vcs.go
@@ -121,7 +121,7 @@ func downloadGit(schemes []string, repo, savedEtag string) (string, string, erro
 	var p []byte
 	var scheme string
 	for i := range schemes {
-		cmd := exec.Command("git", "ls-remote", "--heads", "--tags", schemes[i]+"://"+repo+".git")
+		cmd := exec.Command("git", "ls-remote", "--heads", "--tags", schemes[i]+"://"+repo)
 		log.Println(strings.Join(cmd.Args, " "))
 		var err error
 		p, err = outputWithTimeout(cmd, lsRemoteTimeout)
@@ -158,7 +158,7 @@ func downloadGit(schemes []string, repo, savedEtag string) (string, string, erro
 		if err := os.MkdirAll(dir, 0777); err != nil {
 			return "", "", err
 		}
-		cmd := exec.Command("git", "clone", scheme+"://"+repo+".git", dir)
+		cmd := exec.Command("git", "clone", scheme+"://"+repo, dir)
 		log.Println(strings.Join(cmd.Args, " "))
 		if err := runWithTimeout(cmd, cloneTimeout); err != nil {
 			return "", "", err


### PR DESCRIPTION
According to https://golang.org/cmd/go/#hdr-Remote_import_paths:

> If the import path is not a known code hosting site and also lacks a version control qualifier, the go tool attempts to fetch the import over https/http and looks for a \<meta\> tag in the document's HTML \<head\>.
>
> The meta tag has the form:
>
>     <meta name="go-import" content="import-prefix vcs repo-root">
>
> The import-prefix is the import path corresponding to the repository root. It must be a prefix or an exact match of the package being fetched with "go get". If it's not an exact match, another http request is made at the prefix to verify the <meta> tags match.
>
> ...
>
> The repo-root is the root of the version control system containing a scheme and not containing a .vcs qualifier.
> 
> For example,
>
>     import "example.org/pkg/foo"
> 
> will result in the following requests:
>
>     https://example.org/pkg/foo?go-get=1 (preferred)
>     http://example.org/pkg/foo?go-get=1  (fallback, only with -insecure)
>
> If that page contains the meta tag
>
>     <meta name="go-import" content="example.org git https://code.org/r/p/exproj">
>
> the go tool will verify that https://example.org/?go-get=1 contains the same meta tag and then git clone https://code.org/r/p/exproj into GOPATH/src/example.org.

Note how the value of repo-root in the go-import meta tag content is "https\://code.org/r/p/exproj", and it results in a `git clone https://code.org/r/p/exproj` operation, rather than `git clone https://code.org/r/p/exproj.git`.

This change fixes the git cloning logic to use the repo-root as the clone URL, rather than appending a ".git" suffix to it. That matches the documented behavior and how `go get` behaves, allowing gddo to display documentation for more Go packages that can be acquired with `go get`.

Resolves #352.