### PR TITLE
Feature/dooman87 show links in examples

### DIFF
--- a/doc/builder.go
+++ b/doc/builder.go
@@ -145,6 +145,7 @@ func removeAssociations(dpkg *doc.Package) {
 
 // builder holds the state used when building the documentation.
 type builder struct {
+	pkgName  string
 	srcs     map[string]*source
 	fset     *token.FileSet
 	examples []*doc.Example
@@ -499,6 +500,7 @@ func newPackage(dir *gosrc.Directory) (*Package, error) {
 	}
 
 	var b builder
+
 	b.srcs = make(map[string]*source)
 	references := make(map[string]bool)
 	for _, file := range dir.Files {
@@ -606,6 +608,7 @@ func newPackage(dir *gosrc.Directory) (*Package, error) {
 		removeAssociations(dpkg)
 	}
 
+	b.pkgName = dpkg.Name
 	pkg.Name = dpkg.Name
 	pkg.Doc = strings.TrimRight(dpkg.Doc, " \t\n\r")
 	pkg.Synopsis = synopsis(pkg.Doc)

--- a/doc/code_test.go
+++ b/doc/code_test.go
@@ -1,0 +1,78 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd.
+
+package doc
+
+import (
+	"go/doc"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+var annotationTests = []struct {
+	src              string
+	desc             string
+	annotationsCount int
+}{
+	{`
+		package e
+
+		import (
+			"fmt"
+		)
+		const C = 1.0
+
+		func ExampleTest() {
+			fmt.Println("%d", C);
+		}
+	`, "Const", 1},
+	{`
+		package e
+
+		type T struct {
+		}
+
+		func ExampleTest() {
+			a := &e.T{}
+		}
+	`, "Type", 1},
+	{`
+		package e
+
+		type T struct {
+		}
+
+		func ExampleTest() {
+			var a e.T
+		}
+	`, "Var", 1},
+}
+
+func TestAnnotation(t *testing.T) {
+	for _, tt := range annotationTests {
+		code := printExample(tt.src)
+
+		if len(code.Annotations) != tt.annotationsCount {
+			t.Errorf("Error in test '%s': expected %d annotation, but found %d", tt.desc, tt.annotationsCount, len(code.Annotations))
+		}
+	}
+}
+
+func printExample(src string) Code {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "src.go", src, 0)
+	if err != nil {
+		panic(err)
+	}
+
+	examples := doc.Examples(f)
+	builder := &builder{}
+	builder.fset = fset
+	builder.pkgName = "e"
+	code, _ := builder.printExample(examples[0])
+	return code
+}


### PR DESCRIPTION
This is a PR for #187 task - *Provide links on types found in the code examples*. 

I used the same approach as in declarations and created the separate visitor to tweak logic for extracting annotations.

Current implementation is showing links for package's:

* variables
* types
* functions

