### PR TITLE
gosrc: Use unmodified clone URL from import meta tag for cloning.

### DIFF
--- a/gosrc/gosrc.go
+++ b/gosrc/gosrc.go
@@ -324,14 +324,17 @@ func getDynamic(client *http.Client, importPath, etag string) (*Directory, error
 		}
 	}
 
-	repo := strings.TrimSuffix(im.repo, "."+im.vcs)
-	i := strings.Index(repo, "://")
+	// clonePath is the repo URL from import meta tag, with the "scheme://" prefix removed.
+	// It should be used for cloning repositories.
+	// repo is the repo URL from import meta tag, with the "scheme://" prefix removed, and
+	// a possible ".vcs" suffix trimmed.
+	i := strings.Index(im.repo, "://")
 	if i < 0 {
 		return nil, NotFoundError{Message: "bad repo URL: " + im.repo}
 	}
-	proto := repo[:i]
-	repo = repo[i+len("://"):]
-	repoVCS := im.repo[i+len("://"):]
+	proto := im.repo[:i]
+	clonePath := im.repo[i+len("://"):]
+	repo := strings.TrimSuffix(clonePath, "."+im.vcs)
 	dirName := importPath[len(im.projectRoot):]
 
 	resolvedPath := repo + dirName
@@ -341,8 +344,8 @@ func getDynamic(client *http.Client, importPath, etag string) (*Directory, error
 		match := map[string]string{
 			"dir":        dirName,
 			"importPath": importPath,
+			"clonePath":  clonePath,
 			"repo":       repo,
-			"repoVCS":    repoVCS, // repoVCS is like repo, but without the vcs suffix trimmed.
 			"scheme":     proto,
 			"vcs":        im.vcs,
 		}

--- a/gosrc/gosrc.go
+++ b/gosrc/gosrc.go
@@ -331,6 +331,7 @@ func getDynamic(client *http.Client, importPath, etag string) (*Directory, error
 	}
 	proto := repo[:i]
 	repo = repo[i+len("://"):]
+	repoVCS := im.repo[i+len("://"):]
 	dirName := importPath[len(im.projectRoot):]
 
 	resolvedPath := repo + dirName
@@ -341,6 +342,7 @@ func getDynamic(client *http.Client, importPath, etag string) (*Directory, error
 			"dir":        dirName,
 			"importPath": importPath,
 			"repo":       repo,
+			"repoVCS":    repoVCS, // repoVCS is like repo, but without the vcs suffix trimmed.
 			"scheme":     proto,
 			"vcs":        im.vcs,
 		}

--- a/gosrc/vcs.go
+++ b/gosrc/vcs.go
@@ -117,11 +117,11 @@ var vcsCmds = map[string]*vcsCmd{
 
 var lsremoteRe = regexp.MustCompile(`(?m)^([0-9a-f]{40})\s+refs/(?:tags|heads)/(.+)$`)
 
-func downloadGit(schemes []string, repo, repoVCS, savedEtag string) (string, string, error) {
+func downloadGit(schemes []string, clonePath, repo, savedEtag string) (string, string, error) {
 	var p []byte
 	var scheme string
 	for i := range schemes {
-		cmd := exec.Command("git", "ls-remote", "--heads", "--tags", schemes[i]+"://"+repoVCS)
+		cmd := exec.Command("git", "ls-remote", "--heads", "--tags", schemes[i]+"://"+clonePath)
 		log.Println(strings.Join(cmd.Args, " "))
 		var err error
 		p, err = outputWithTimeout(cmd, lsRemoteTimeout)
@@ -158,7 +158,7 @@ func downloadGit(schemes []string, repo, repoVCS, savedEtag string) (string, str
 		if err := os.MkdirAll(dir, 0777); err != nil {
 			return "", "", err
 		}
-		cmd := exec.Command("git", "clone", scheme+"://"+repoVCS, dir)
+		cmd := exec.Command("git", "clone", scheme+"://"+clonePath, dir)
 		log.Println(strings.Join(cmd.Args, " "))
 		if err := runWithTimeout(cmd, cloneTimeout); err != nil {
 			return "", "", err
@@ -183,12 +183,12 @@ func downloadGit(schemes []string, repo, repoVCS, savedEtag string) (string, str
 	return tag, etag, nil
 }
 
-func downloadSVN(schemes []string, repo, repoVCS, savedEtag string) (string, string, error) {
+func downloadSVN(schemes []string, clonePath, repo, savedEtag string) (string, string, error) {
 	var scheme string
 	var revno string
 	for i := range schemes {
 		var err error
-		revno, err = getSVNRevision(schemes[i] + "://" + repoVCS)
+		revno, err = getSVNRevision(schemes[i] + "://" + clonePath)
 		if err == nil {
 			scheme = schemes[i]
 			break
@@ -212,7 +212,7 @@ func downloadSVN(schemes []string, repo, repoVCS, savedEtag string) (string, str
 		if err := os.MkdirAll(dir, 0777); err != nil {
 			return "", "", err
 		}
-		cmd := exec.Command("svn", "checkout", scheme+"://"+repoVCS, "-r", revno, dir)
+		cmd := exec.Command("svn", "checkout", scheme+"://"+clonePath, "-r", revno, dir)
 		log.Println(strings.Join(cmd.Args, " "))
 		if err := runWithTimeout(cmd, cloneTimeout); err != nil {
 			return "", "", err
@@ -271,7 +271,7 @@ func getVCSDir(client *http.Client, match map[string]string, etagSaved string) (
 
 	// Download and checkout.
 
-	tag, etag, err := cmd.download(schemes, match["repo"], match["repoVCS"], etagSaved)
+	tag, etag, err := cmd.download(schemes, match["clonePath"], match["repo"], etagSaved)
 	if err != nil {
 		return nil, err
 	}

--- a/gosrc/vcs.go
+++ b/gosrc/vcs.go
@@ -101,7 +101,7 @@ func lookupURLTemplate(repo, dir, tag string) (*urlTemplates, map[string]string)
 
 type vcsCmd struct {
 	schemes  []string
-	download func([]string, string, string) (string, string, error)
+	download func([]string, string, string, string) (string, string, error)
 }
 
 var vcsCmds = map[string]*vcsCmd{
@@ -117,11 +117,11 @@ var vcsCmds = map[string]*vcsCmd{
 
 var lsremoteRe = regexp.MustCompile(`(?m)^([0-9a-f]{40})\s+refs/(?:tags|heads)/(.+)$`)
 
-func downloadGit(schemes []string, repo, savedEtag string) (string, string, error) {
+func downloadGit(schemes []string, repo, repoVCS, savedEtag string) (string, string, error) {
 	var p []byte
 	var scheme string
 	for i := range schemes {
-		cmd := exec.Command("git", "ls-remote", "--heads", "--tags", schemes[i]+"://"+repo)
+		cmd := exec.Command("git", "ls-remote", "--heads", "--tags", schemes[i]+"://"+repoVCS)
 		log.Println(strings.Join(cmd.Args, " "))
 		var err error
 		p, err = outputWithTimeout(cmd, lsRemoteTimeout)
@@ -158,7 +158,7 @@ func downloadGit(schemes []string, repo, savedEtag string) (string, string, erro
 		if err := os.MkdirAll(dir, 0777); err != nil {
 			return "", "", err
 		}
-		cmd := exec.Command("git", "clone", scheme+"://"+repo, dir)
+		cmd := exec.Command("git", "clone", scheme+"://"+repoVCS, dir)
 		log.Println(strings.Join(cmd.Args, " "))
 		if err := runWithTimeout(cmd, cloneTimeout); err != nil {
 			return "", "", err
@@ -183,12 +183,12 @@ func downloadGit(schemes []string, repo, savedEtag string) (string, string, erro
 	return tag, etag, nil
 }
 
-func downloadSVN(schemes []string, repo, savedEtag string) (string, string, error) {
+func downloadSVN(schemes []string, repo, repoVCS, savedEtag string) (string, string, error) {
 	var scheme string
 	var revno string
 	for i := range schemes {
 		var err error
-		revno, err = getSVNRevision(schemes[i] + "://" + repo)
+		revno, err = getSVNRevision(schemes[i] + "://" + repoVCS)
 		if err == nil {
 			scheme = schemes[i]
 			break
@@ -212,7 +212,7 @@ func downloadSVN(schemes []string, repo, savedEtag string) (string, string, erro
 		if err := os.MkdirAll(dir, 0777); err != nil {
 			return "", "", err
 		}
-		cmd := exec.Command("svn", "checkout", scheme+"://"+repo, "-r", revno, dir)
+		cmd := exec.Command("svn", "checkout", scheme+"://"+repoVCS, "-r", revno, dir)
 		log.Println(strings.Join(cmd.Args, " "))
 		if err := runWithTimeout(cmd, cloneTimeout); err != nil {
 			return "", "", err
@@ -271,7 +271,7 @@ func getVCSDir(client *http.Client, match map[string]string, etagSaved string) (
 
 	// Download and checkout.
 
-	tag, etag, err := cmd.download(schemes, match["repo"], etagSaved)
+	tag, etag, err := cmd.download(schemes, match["repo"], match["repoVCS"], etagSaved)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This fixes a regression in #353 that caused `vcs.download` to fail for some valid go gettable packages because an incorrect clone URL value was being used.

The clone URL value had a possible ".git" suffix trimmed, which is not correct according to how remote import path resolution is documented at https://golang.org/cmd/go/#hdr-Remote_import_paths.

Fixes #356.