### PR TITLE
gosrc: Accept domain.root in IsValidRemotePath.

### DIFF
--- a/gosrc/path.go
+++ b/gosrc/path.go
@@ -26,11 +26,6 @@ func IsValidRemotePath(importPath string) bool {
 
 	parts := strings.Split(importPath, "/")
 
-	if len(parts) <= 1 {
-		// Import path must contain at least one "/".
-		return false
-	}
-
 	if !validTLDs[path.Ext(parts[0])] {
 		return false
 	}

--- a/gosrc/path_test.go
+++ b/gosrc/path_test.go
@@ -20,6 +20,7 @@ var goodImportPaths = []string{
 	"launchpad.net/~user/foo/trunk",
 	"launchpad.net/~user/+junk/version",
 	"github.com/user/repo/_ok/x",
+	"exampleproject.com",
 }
 
 var badImportPaths = []string{
@@ -27,7 +28,6 @@ var badImportPaths = []string{
 	"foo.",
 	".bar",
 	"favicon.ico",
-	"exmpple.com",
 	"github.com/user/repo/.ignore/x",
 }
 


### PR DESCRIPTION
This change mirrors the change done in https://golang.org/cl/12193.

Fixes #355.