### PR TITLE
Fallback for clonePath if `<repo>.<vcs><dir>` pattern matched

### DIFF
--- a/gosrc/vcs.go
+++ b/gosrc/vcs.go
@@ -269,9 +269,16 @@ func getVCSDir(client *http.Client, match map[string]string, etagSaved string) (
 		}
 	}
 
+	clonePath, ok := match["clonePath"]
+	if !ok {
+		// clonePath may be unset if we're being called via the generic repo.vcs/dir regexp matcher.
+		// In that case, set it to the repo value.
+		clonePath = match["repo"]
+	}
+
 	// Download and checkout.
 
-	tag, etag, err := cmd.download(schemes, match["clonePath"], match["repo"], etagSaved)
+	tag, etag, err := cmd.download(schemes, clonePath, match["repo"], etagSaved)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Pattern for importPath in gosrc/vcs.go does not contain clonePath, as a result something like `example.com/foo/bar.git` handled incorrectly:
```
2016/02/10 19:15:30 git ls-remote --heads --tags http://
2016/02/10 19:15:31 git ls-remote --heads --tags https://
2016/02/10 19:15:31 git ls-remote --heads --tags ssh://
2016/02/10 19:15:31 git ls-remote --heads --tags git://
2016/02/10 19:15:31 web   fetch: 1010 notfound: VCS not found example.com/foo/bar.git
```