### PR TITLE
talksapp: fix environment variable access

### DIFF
--- a/talksapp/main.go
+++ b/talksapp/main.go
@@ -35,7 +35,6 @@ var (
 	}
 	homeArticle  = loadHomeArticle()
 	contactEmail = "golang-dev@googlegroups.com"
-	github       = httputil.NewAuthTransportFromEnvironment(nil)
 
 	// used for mocking in tests
 	getPresentation = gosrc.GetPresentation
@@ -120,6 +119,8 @@ func writeTextHeader(w http.ResponseWriter, status int) {
 
 func httpClient(r *http.Request) *http.Client {
 	c := appengine.NewContext(r)
+	github := httputil.NewAuthTransportFromEnvironment(nil)
+
 	return &http.Client{
 		Transport: &httputil.AuthTransport{
 			Token:        github.Token,


### PR DESCRIPTION
Environment variables in Go are not accessible until a first request
arrives: [docs](https://cloud.google.com/appengine/docs/go/config/appconfig#Go_app_yaml_Defining_environment_variables).

The previous code was accessing them at variable declaration time,
obtaining empty values and causing authentication issues.

Change-Id: Id64e7c93453f9aded04d935cf49eccba0f9a6923