### PR TITLE
Index full import path. Treat urls and float numbers as one term.

### DIFF
--- a/database/index.go
+++ b/database/index.go
@@ -21,7 +21,7 @@ func isStandardPackage(path string) bool {
 }
 
 func isTermSep(r rune) bool {
-	return unicode.IsSpace(r) || unicode.IsPunct(r) || unicode.IsSymbol(r)
+	return unicode.IsSpace(r) || unicode.IsPunct(r) && r != '.' || unicode.IsSymbol(r)
 }
 
 func normalizeProjectRoot(projectRoot string) string {
@@ -43,7 +43,7 @@ func term(s string) string {
 	if x, ok := synonyms[s]; ok {
 		s = x
 	}
-	return stem(s)
+	return stem(strings.Trim(s, "."))
 }
 
 var httpPat = regexp.MustCompile(`https?://\S+`)
@@ -125,11 +125,10 @@ func documentTerms(pdoc *doc.Package, score float64) []string {
 
 	if score > 0 {
 
-		if isStandardPackage(pdoc.ImportPath) {
-			for _, term := range parseQuery(pdoc.ImportPath) {
-				terms[term] = true
-			}
-		} else {
+		for _, term := range parseQuery(pdoc.ImportPath) {
+			terms[term] = true
+		}
+		if !isStandardPackage(pdoc.ImportPath) {
 			terms["all:"] = true
 			for _, term := range parseQuery(pdoc.ProjectName) {
 				terms[term] = true

--- a/database/index_test.go
+++ b/database/index_test.go
@@ -77,13 +77,13 @@ var indexTests = []struct {
 	},
 		[]string{
 			"all:",
-			"5849", "cly", "defin", "dir", "go",
+			"5849", "cly", "defin", "dir", "github.com", "go",
 			"import:bytes", "import:crypto/hmac", "import:crypto/sha1",
 			"import:encoding/base64", "import:encoding/binary", "import:errors",
 			"import:fmt", "import:io", "import:io/ioutil", "import:net/http",
 			"import:net/url", "import:regexp", "import:sort", "import:strconv",
 			"import:strings", "import:sync", "import:time", "interfac",
-			"oau", "project:github.com/user/repo", "rfc", "subset",
+			"oau", "project:github.com/user/repo", "repo", "rfc", "subset", "us",
 		},
 	},
 }


### PR DESCRIPTION
Fixes Issue #366 and #384.

For all projects we now index the full import path. So user can search for example gddo/doc.

Handle urls and float numbers as one term, such as v.io, 0.8.