### PR TITLE
gddo-server: log configuration settings as Debug only

### DIFF
--- a/gddo-server/config.go
+++ b/gddo-server/config.go
@@ -117,7 +117,7 @@ func loadConfig(ctx context.Context, args []string) (*viper.Viper, error) {
 	// Set defaults based on other configs
 	setDefaults(v)
 
-	log.Info(ctx, "config values loaded", "values", v.AllSettings())
+	log.Debug(ctx, "config values loaded", "values", v.AllSettings())
 	return v, nil
 }
 


### PR DESCRIPTION
To prevent leaking sensitive data in the normal case, use the Debug
logging level instead of Info when logging credentials.

There are very sensitive pieces of data in the settings, namely GitHub
secrets, Redis database passwords, etc. In the normal case, these are
logged. To prevent accidental leaking of credentials, only print
settings map when logging in Debug mode.