### PR TITLE
FIX: Missing HSTS-header

### DIFF
--- a/gddo-server/main.go
+++ b/gddo-server/main.go
@@ -1016,8 +1016,9 @@ func main() {
 			}
 		}
 	}()
-	http.Handle("/", s)
-	log.Fatal(http.ListenAndServe(s.v.GetString(ConfigBindAddress), s))
+	ss := httputil.HSTS(s)
+	http.Handle("/", ss)
+	log.Fatal(http.ListenAndServe(s.v.GetString(ConfigBindAddress), ss))
 }
 
 // removeInternal removes the internal packages from the given package

--- a/httputil/middleware.go
+++ b/httputil/middleware.go
@@ -1,0 +1,14 @@
+package httputil
+
+import "net/http"
+
+// HSTS will automatically inform the browser that the website can only be accessed through HTTPS.
+func HSTS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// This enforces the use of HTTPS for 1 year, including present and future subdomains.
+		// Chrome and Mozilla Firefox maintain an HSTS preload list
+		// issue : golang.org/issue/26162
+		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/httputil/middleware_test.go
+++ b/httputil/middleware_test.go
@@ -1,0 +1,23 @@
+package httputil
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHSTS(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	respRecorder := httptest.NewRecorder()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "")
+	})
+	handlerWithMiddlewareHSTS := HSTS(handler)
+	handlerWithMiddlewareHSTS.ServeHTTP(respRecorder, req)
+	want := "max-age=31536000; includeSubDomains; preload"
+	got := respRecorder.Header().Get("Strict-Transport-Security")
+	if got != want {
+		t.Error("middlewareHSTS do not add HSTS header")
+	}
+}


### PR DESCRIPTION
ADD HSTS header to godoc.org

Please review my changes

# Related
https://github.com/golang/go/issues/26162