### PR TITLE
gddo-server: fix expanding examples containing reserved characters

### DIFF
--- a/gddo-server/assets/templates/pkg.html
+++ b/gddo-server/assets/templates/pkg.html
@@ -169,7 +169,7 @@
     <div class="panel-group">
     {{range .}}
       <div class="panel panel-default" id="example-{{.ID}}">
-        <div class="panel-heading"><a class="accordion-toggle" data-toggle="collapse" href="#ex-{{.ID}}">Example{{with .Example.Name}} ({{.}}){{end}}</a></div>
+        <div class="panel-heading"><a class="accordion-toggle" data-toggle="collapse" data-target="#ex-{{.ID}}" href="#ex-{{.ID}}">Example{{with .Example.Name}} ({{.}}){{end}}</a></div>
         <div id="ex-{{.ID}}" class="panel-collapse collapse"><div class="panel-body">
           {{with .Example.Doc}}<p>{{.|comment}}{{end}}
           <p>Code:{{if .Play}}<span class="pull-right"><a href="?play={{.ID}}">play</a>&nbsp;</span>{{end}}


### PR DESCRIPTION
The href attribute is percent-encoded by html/template, which ends up
breaking how Bootstrap links the heading to it's target. We can instead
use data-target to explicitly name the target, without it being
percent-encoded.

Fixes #570