### PR TITLE
Allow username in package name

### DIFF
--- a/gosrc/path.go
+++ b/gosrc/path.go
@@ -30,7 +30,14 @@ func IsValidRemotePath(importPath string) bool {
 		return false
 	}
 
-	if !validHost.MatchString(parts[0]) {
+	// use only the hostname, if there is a username in the package name
+	hostparts := strings.Split(parts[0], "@")
+	host := hostparts[0]
+	if len(hostparts) > 1 {
+		host = hostparts[1]
+	}
+
+	if !validHost.MatchString(host) {
 		return false
 	}
 


### PR DESCRIPTION
https://github.com/golang/gddo/issues/585

Don't fail if a vanity service returns
a package name with a SSH url and a
username, such as ssh://git@example.com/org/package.