### PR TITLE
talksapp: use Go 1.9, update bot.html URLs

### DIFF
--- a/talksapp/README.md
+++ b/talksapp/README.md
@@ -11,3 +11,4 @@ Development Environment Setup
 - `$ sh setup.sh`
 - Run the server using the `goapp serve prod.yaml` command.
 - Run the tests using the `goapp test` command.
+- Deploy to production using the `gcloud app --project=go-talks deploy --no-promote prod.yaml` command.

--- a/talksapp/app.yaml
+++ b/talksapp/app.yaml
@@ -1,7 +1,5 @@
-application: go-talks
-version: 1
 runtime: go
-api_version: go1.8
+api_version: go1.9
 
 handlers:
 - url: /robots\.txt
@@ -24,7 +22,7 @@ handlers:
   secure: always
 
 env_variables:
-  CONTACT_EMAIL: ''        # set contact email for /-/bot.html
+  CONTACT_EMAIL: ''        # set contact email for /bot.html
   GITHUB_CLIENT_ID: ''     # used to increase rate-limits; see https://github.com/settings/applications/new
   GITHUB_CLIENT_SECRET: '' # used to increase rate-limits; see https://github.com/settings/applications/new
   GITHUB_TOKEN: ''         # personal token used for authentication; see https://github.com/settings/tokens/new

--- a/talksapp/main.go
+++ b/talksapp/main.go
@@ -138,7 +138,7 @@ func httpClient(r *http.Request) *http.Client {
 			GithubClientID:     githubClientID,
 			GithubClientSecret: githubClientSecret,
 			Base:               &urlfetch.Transport{Context: ctx},
-			UserAgent:          fmt.Sprintf("%s (+http://%s/-/bot)", appengine.AppID(ctx), r.Host),
+			UserAgent:          fmt.Sprintf("%s (+https://%s/bot.html)", appengine.AppID(ctx), r.Host),
 		},
 	}
 }


### PR DESCRIPTION
Go 1.8 isn't supported anymore by goapp test (which is run by Travis CI).

Also add deploy command to README.