### PR TITLE
Add extra scopes

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -125,6 +125,8 @@ func newDBDialer(server string, logConn bool) func() (c redis.Conn, err error) {
 func newRemoteClient(host string) (*remote_api.Client, error) {
 	client, err := google.DefaultClient(context.TODO(),
 		"https://www.googleapis.com/auth/appengine.apis",
+		"https://www.googleapis.com/auth/userinfo.email",
+		"https://www.googleapis.com/auth/cloud-platform",
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
After trying to deploy this project with remote search enabled I encountered permissions errors when trying to run the gddo server. 

 I have tried granting the service account different roles (App Engine Admin, Cloud Datastore Owner, Storage Admin, Owner role) but whenever you start the gddo server it returns a 401 error - `error creating server:open database: unable to contact server: bad response 401; body: "You must be logged in as an administrator to access this.\n"`

I think this is happening because the Default client is missing these two scopes