### PR TITLE
Removed max-width to make site more comfortable to read

### DIFF
--- a/gddo-server/assets/site.css
+++ b/gddo-server/assets/site.css
@@ -1,7 +1,6 @@
 html { background-color: whitesmoke; }
 body { background-color: white; }
 h4 { margin-top: 20px; }
-.container { max-width: 728px; }
 
 #x-projnav {
     min-height: 20px;


### PR DESCRIPTION
Some docs have sections which are hard to read without scrolling (referenced here: https://github.com/golang/gddo/issues/627). This is to remove the `max-width` property to make docs a little more legible.

### Without Change
![image](https://user-images.githubusercontent.com/13970649/66955656-71327100-f028-11e9-91fe-2bf01c5f1ec0.png)

### With Change
![image](https://user-images.githubusercontent.com/13970649/66955893-eaca5f00-f028-11e9-8975-afe387d4b929.png)
