### PR TITLE
feat(gddo-server): make log level configurable, default to info

### DIFF
--- a/gddo-server/config.go
+++ b/gddo-server/config.go
@@ -180,7 +180,7 @@ func buildFlags() *pflag.FlagSet {
 	flags.String(ConfigGAERemoteAPI, "", "Remoteapi endpoint for App Engine Search. Defaults to serviceproxy-dot-${project}.appspot.com.")
 	flags.Float64(ConfigTraceSamplerFraction, 0.1, "Fraction of the requests sampled by the trace API.")
 	flags.Float64(ConfigTraceSamplerMaxQPS, 5, "Max number of requests sampled every second by the trace API.")
-	flags.String(ConfigLogLevel, "info", "Determine which level of logs to print.")
+	flags.String(ConfigLogLevel, "info", "Determine which level of logs to print. (debug, info, warn, error, crit)")
 
 	return flags
 }

--- a/gddo-server/config.go
+++ b/gddo-server/config.go
@@ -23,6 +23,7 @@ const (
 	githubTokenEnvVar        = "GITHUB_TOKEN"
 	githubClientIDEnvVar     = "GITHUB_CLIENT_ID"
 	githubClientSecretEnvVar = "GITHUB_CLIENT_SECRET"
+	logLevelEnvVar           = "LOG_LEVEL"
 )
 
 const (
@@ -68,6 +69,9 @@ const (
 
 	// Pub/Sub Config
 	ConfigCrawlPubSubTopic = "crawl-events"
+
+	// Log Config
+	ConfigLogLevel = "log-level"
 )
 
 func loadConfig(ctx context.Context, args []string) (*viper.Viper, error) {
@@ -111,6 +115,7 @@ func loadConfig(ctx context.Context, args []string) (*viper.Viper, error) {
 	v.BindEnv(ConfigGithubToken, githubTokenEnvVar)
 	v.BindEnv(ConfigGithubClientID, githubClientIDEnvVar)
 	v.BindEnv(ConfigGithubClientSecret, githubClientSecretEnvVar)
+	v.BindEnv(ConfigLogLevel, logLevelEnvVar)
 
 	// Read from config.
 	if err := readViperConfig(ctx, v); err != nil {
@@ -119,6 +124,8 @@ func loadConfig(ctx context.Context, args []string) (*viper.Viper, error) {
 
 	// Set defaults based on other configs
 	setDefaults(v)
+
+	log.SetLevel(v.GetString(ConfigLogLevel))
 
 	log.Debug(ctx, "config values loaded", "values", v.AllSettings())
 	return v, nil
@@ -173,6 +180,7 @@ func buildFlags() *pflag.FlagSet {
 	flags.String(ConfigGAERemoteAPI, "", "Remoteapi endpoint for App Engine Search. Defaults to serviceproxy-dot-${project}.appspot.com.")
 	flags.Float64(ConfigTraceSamplerFraction, 0.1, "Fraction of the requests sampled by the trace API.")
 	flags.Float64(ConfigTraceSamplerMaxQPS, 5, "Max number of requests sampled every second by the trace API.")
+	flags.String(ConfigLogLevel, "info", "Determine which level of logs to print.")
 
 	return flags
 }

--- a/log/log.go
+++ b/log/log.go
@@ -26,6 +26,14 @@ func FromContext(ctx context.Context) log15.Logger {
 	return log15.Root()
 }
 
+func SetLevel(level string) {
+	root := log15.Root()
+	lvl, err := log15.LvlFromString(level)
+	if err != nil {
+		root.SetHandler(log15.LvlFilterHandler(lvl, root.GetHandler()))
+	}
+}
+
 // NewContext creates a new context containing the given logger. It is not
 // recommended for use and may be removed in the future.
 func NewContext(ctx context.Context, l log15.Logger) context.Context {


### PR DESCRIPTION
This PR adds the ability to configure the log level for the server. Currently, the default is to log everything (including debug) which logs secrets like the github token and is a security risk.

This is similar to #554 but opts to integrate with viper to keep this consistent, in addition to allowing this to be set as a CLI flag.

Lastly, the default log level becomes "info" which is probably what most people want, and they can opt in to "debug" if needed when troubleshooting.